### PR TITLE
✨ Modular holofoil supporter card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
 			"name": "talktype",
 			"version": "0.9.0",
 			"dependencies": {
+				"@dicebear/collection": "9.4.2",
+				"@dicebear/core": "9.4.2",
 				"@google/genai": "1.52.0",
 				"@netlify/blobs": "10.7.7",
 				"@xenova/transformers": "^2.17.2",
@@ -190,6 +192,435 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@dicebear/adventurer": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/adventurer/-/adventurer-9.4.2.tgz",
+			"integrity": "sha512-jqYp834ZmGDA9HBBDQAdgF1O2UTCwHF4vVrktXWa2Dppp1JczPL5HnVOWsjtrLmXNn61Wd6OLmBb2e6rhzp3ig==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/adventurer-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/adventurer-neutral/-/adventurer-neutral-9.4.2.tgz",
+			"integrity": "sha512-5xgkG/mNL4j3Q4SJGQLBU/KnU90tng8Ze5ofThD+55wi0oeY/nSAUowg6UFCmHrktjifj/MEx3CQqbpcPWtfIA==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/avataaars": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/avataaars/-/avataaars-9.4.2.tgz",
+			"integrity": "sha512-3x9jKFkOkFSPmpTbt9xvhiU2E1GX7beCSsX0tXRUShj8x6+5Ks9yBRT1VlkySbnXrZ/GglADGg7vJ/D2uIx1Yw==",
+			"license": "See LICENSE file",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/avataaars-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/avataaars-neutral/-/avataaars-neutral-9.4.2.tgz",
+			"integrity": "sha512-/eNrp0YCNJRwQXqOloLm1+3Ss2C+pMpUQIGkbEnGsP1UK+13Ge80ggDDof1HpdqvG9HAZcKa7hnbG/0HSwyDSw==",
+			"license": "See LICENSE file",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/big-ears": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/big-ears/-/big-ears-9.4.2.tgz",
+			"integrity": "sha512-mNfz3ppNA7UBq0IO3nXCiV5pFPG7c1DfzRB0foNU2Wo1XXT8FIcSY2BvDlYqorZTOUOz7dHb0vx06hqvG0HP5w==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/big-ears-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/big-ears-neutral/-/big-ears-neutral-9.4.2.tgz",
+			"integrity": "sha512-M8Ozmzza4eY4hpLOYULgJxMYmBA0CsBnrE15/xw6LZkEREXnrX5z0NJsf8hUfdyF6BWZ+RBgzoiav32DAC5zcg==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/big-smile": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/big-smile/-/big-smile-9.4.2.tgz",
+			"integrity": "sha512-hmT5i7rcPPhStjZyg28pbIhdTnnMBzK3RObI0vKCpY30EFrzaPkkdDL6Ck5fAFBdvDIW1EpOJkenyR0XPmhgbQ==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/bottts": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/bottts/-/bottts-9.4.2.tgz",
+			"integrity": "sha512-tsx+dII7EFUCVA8URj66G1GqORCCVduCAx4dY2prEY2IeFianVpkntXuFsWZ9BBGx1NZFndvDith5oTwKMQPbQ==",
+			"license": "See LICENSE file",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/bottts-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/bottts-neutral/-/bottts-neutral-9.4.2.tgz",
+			"integrity": "sha512-kFNwWt6j+gzZ5n5Pz7WVwePubREAQOF8ZwWA9ztwVYDVMLnOChWbAofy5FED4j5md2MXFH2EgLCFCMr5K2BmIA==",
+			"license": "See LICENSE file",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/collection": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/collection/-/collection-9.4.2.tgz",
+			"integrity": "sha512-KArubv7if8H7j9sIfpDK2hJJqrdNVR5zMPAMOSpIU2JPyXx8TC9o5wsmXb8il5wOHgaS9Q/cla7jUNIiDD7Gsg==",
+			"license": "MIT",
+			"dependencies": {
+				"@dicebear/adventurer": "9.4.2",
+				"@dicebear/adventurer-neutral": "9.4.2",
+				"@dicebear/avataaars": "9.4.2",
+				"@dicebear/avataaars-neutral": "9.4.2",
+				"@dicebear/big-ears": "9.4.2",
+				"@dicebear/big-ears-neutral": "9.4.2",
+				"@dicebear/big-smile": "9.4.2",
+				"@dicebear/bottts": "9.4.2",
+				"@dicebear/bottts-neutral": "9.4.2",
+				"@dicebear/croodles": "9.4.2",
+				"@dicebear/croodles-neutral": "9.4.2",
+				"@dicebear/dylan": "9.4.2",
+				"@dicebear/fun-emoji": "9.4.2",
+				"@dicebear/glass": "9.4.2",
+				"@dicebear/icons": "9.4.2",
+				"@dicebear/identicon": "9.4.2",
+				"@dicebear/initials": "9.4.2",
+				"@dicebear/lorelei": "9.4.2",
+				"@dicebear/lorelei-neutral": "9.4.2",
+				"@dicebear/micah": "9.4.2",
+				"@dicebear/miniavs": "9.4.2",
+				"@dicebear/notionists": "9.4.2",
+				"@dicebear/notionists-neutral": "9.4.2",
+				"@dicebear/open-peeps": "9.4.2",
+				"@dicebear/personas": "9.4.2",
+				"@dicebear/pixel-art": "9.4.2",
+				"@dicebear/pixel-art-neutral": "9.4.2",
+				"@dicebear/rings": "9.4.2",
+				"@dicebear/shapes": "9.4.2",
+				"@dicebear/thumbs": "9.4.2",
+				"@dicebear/toon-head": "9.4.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/core": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/core/-/core-9.4.2.tgz",
+			"integrity": "sha512-MF0042+Z3s8PGZKZLySfhft28bUa3B1iq0e5NSjCvY8gfMi5aIH/iRJGRJa1N9Jz1BNkxYb4yvJ/N9KO8Z6Y+w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@dicebear/croodles": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/croodles/-/croodles-9.4.2.tgz",
+			"integrity": "sha512-6VoO0JviIf7dKKMBTL/SMXxWhnXHaZuzufX90G0nXxS77ELG1YkGNMaZzawizN4C09Gbya2gJkozqrWiJN/aGw==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/croodles-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/croodles-neutral/-/croodles-neutral-9.4.2.tgz",
+			"integrity": "sha512-oG5IeUdtiYshQ89gkAVcl5w3xAEi5UZX2fTzIyelpBPCG176l7VuuFzlxi2umnB3E6LVHYy06DXvUo/p+rXB2Q==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/dylan": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/dylan/-/dylan-9.4.2.tgz",
+			"integrity": "sha512-1vQvRu9x9DrwFxhFaIU2rf0EUL04yDTbAt7fHyAjM0mEsKzTD4mRNf95tCRuavCoW6W48u7A/OY6jyIub6kxLQ==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/fun-emoji": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/fun-emoji/-/fun-emoji-9.4.2.tgz",
+			"integrity": "sha512-kqB6LPkdYCdEU/mwbyz34xLzoNUKL6ARcoo3fr5ASq9D6ZE07qIKybC3xv5+CPz7VmspJ1Q3c/VVWVMDRP7Twg==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/glass": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/glass/-/glass-9.4.2.tgz",
+			"integrity": "sha512-z5qUogHQ1b6UJ2zCqT848mU2U9DKbVDhiX6GPDjD7tYLisCCJVisH9p6WyNdHvflUd4SHkA6gRqVJIh2v2HnTA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/icons": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/icons/-/icons-9.4.2.tgz",
+			"integrity": "sha512-QSMMz0NA03ypSGhXC8HQX8FSj8lYT+/5yqH+/N03OH2IjL0q7wwGZ7nqsrtlRp76O5WqMTwGfSbTUUYPjFr+Xw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/identicon": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/identicon/-/identicon-9.4.2.tgz",
+			"integrity": "sha512-JVDSmZsv11mSWqwAktK5x9Bslht2xY3TFUn8xzu6slAYe1Z7hEXZ76eb+UJ6F4qEzdwZ7xPWzAS6Nb0Y3A0pww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/initials": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/initials/-/initials-9.4.2.tgz",
+			"integrity": "sha512-yePuIUasmwtl9IrtB6rEzE/zb5fImKP/neW0CdcTC2MwLgMuP1GLHEGRgg1zI8exIh+PMv1YdLGyyUuRTE2Qpw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/lorelei": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/lorelei/-/lorelei-9.4.2.tgz",
+			"integrity": "sha512-YMv6vnriW6VLFDsreKuOnUFFno6SRe7+7X7R7zPY0rZ+MaHX9V3jcioIG+1PSjIHEDfOLUHpr5vd1JBWv8y7UA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/lorelei-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/lorelei-neutral/-/lorelei-neutral-9.4.2.tgz",
+			"integrity": "sha512-yspanTthA5vh6iCdeLzn6xZ4yYMYRcfcxblcgSvHTF1ut0bjAXtw5SXzZ6aJTrJWiHkzYOQuTOR6GVYiW80Q7w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/micah": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/micah/-/micah-9.4.2.tgz",
+			"integrity": "sha512-e4D3W/OlChSsLo7Llwsy0J18vk0azJqF/uFoY+EKACCNHBc1HGNsqVvu2CTf+OWOA8wTyAK6UkjBN5p01r7D+g==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/miniavs": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/miniavs/-/miniavs-9.4.2.tgz",
+			"integrity": "sha512-wLwyFNNUnDRd3BbhSBhXR0XEpX8sG0/xDA5M/OkDoapLqZnnI48YLUSDd2N5QTAVMmcSEuZOYxkcnj7WW79vlg==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/notionists": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/notionists/-/notionists-9.4.2.tgz",
+			"integrity": "sha512-ZCySq+nxcD/x4xyYgytcj2N9uY3gxrL+qpnmOdp2BdA221KacVrxlsUPpIgEMqxS2rMmBQXfxg129Pzn4ycIpA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/notionists-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/notionists-neutral/-/notionists-neutral-9.4.2.tgz",
+			"integrity": "sha512-AyD9kEfVxQUwDGf4Op059gVmYIOAkTKg3dtE9h9mEKP7zl/kMy5B67BFFOo7sB0mXCjzAegZ6ekGU02E8+hIHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/open-peeps": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/open-peeps/-/open-peeps-9.4.2.tgz",
+			"integrity": "sha512-i01tLgtp2g937T81sVeAOVlqsCtiTck/Kw20g7hN80+7xrXjOUepz2HPLy3HeiMjwjMGRy5o54kSd0/8Ht4Dqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/personas": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/personas/-/personas-9.4.2.tgz",
+			"integrity": "sha512-NJlkvI5F5gugt6t2+7QrYNTwQC7+4IQZS3vG0dYk2BncxOHax0BuLovdSdiAesTL4ZkytFYIydWmKmV2/xcUwg==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/pixel-art": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/pixel-art/-/pixel-art-9.4.2.tgz",
+			"integrity": "sha512-peHf7oKICDgBZ8dUyj+txPnS7VZEWgvKE+xW4mNQqBt6dYZIjmva2shOVHn0b1JU+FDxMx3uIkWVixKdUq4WGg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/pixel-art-neutral": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/pixel-art-neutral/-/pixel-art-neutral-9.4.2.tgz",
+			"integrity": "sha512-9e9Lz554uQvWaXV2P17ss+hPa6rTyuAKBtB8zk8ECjHiZzIl61N/KcTVLZ4dILVZwj7gYriaLo16QEqvL2GJCg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/rings": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/rings/-/rings-9.4.2.tgz",
+			"integrity": "sha512-Pc3ymWrRDQPJFNrbbLt7RJrzGvUuuxUiDkrfLhoVE+B6mZWEL1PC78DPbS1yUWYLErJOpJuM2GSwXmTbVjWf+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/shapes": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/shapes/-/shapes-9.4.2.tgz",
+			"integrity": "sha512-AFL6jAaiLztvcqyq+ds+lWZu6Vbp3PlGWhJeJRm842jxtiluJpl6r4f6nUXP2fdMz7MNpDzXfLooQK9E04NbUQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/thumbs": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/thumbs/-/thumbs-9.4.2.tgz",
+			"integrity": "sha512-ccWvDBqbkWS5uzHbsg5L6uML6vBfX7jT3J3jHCQksvz8haHItxTK02w+6e1UavZUsvza4lG5X/XY3eji3siJ4Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
+			}
+		},
+		"node_modules/@dicebear/toon-head": {
+			"version": "9.4.2",
+			"resolved": "https://registry.npmjs.org/@dicebear/toon-head/-/toon-head-9.4.2.tgz",
+			"integrity": "sha512-lwFeSXyAnaKnCfMt9TiJwnD1cXQUGkey/0h6i/+4TVHVMCz5/Ri5u1ynovPNHy1SnBf858QwoXHkxilGLwQX/g==",
+			"license": "(MIT AND CC-BY-4.0)",
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@dicebear/core": "^9.0.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
@@ -3499,7 +3930,6 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
 		"vitest": "^3.2.4"
 	},
 	"dependencies": {
+		"@dicebear/collection": "9.4.2",
+		"@dicebear/core": "9.4.2",
 		"@google/genai": "1.52.0",
 		"@netlify/blobs": "10.7.7",
 		"@xenova/transformers": "^2.17.2",

--- a/src/lib/cartridges/MembershipCard.svelte
+++ b/src/lib/cartridges/MembershipCard.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 	import { generateMemberIdentity } from './identityUtils.js';
+	import { hexToRgba, mixHex } from './passportPalettes.js';
 	import { buildPassportAvatar } from './passportAvatar.js';
 	import { selectSkin, selectNamedSkin } from './passportSkins.js';
 	import { buildPassportSyncUrl, getVaultHandshakeQR } from '$lib/services/qrHandshakeService.js';
@@ -72,9 +73,26 @@
 		`--p-ink: ${inkColor}`,
 		`--p-ink-soft: ${inkSoftColor}`,
 		`--p-glow: ${palette.glow}`,
-		// Pre-mixed glow alphas so frame shadows can reference them simply.
-		`--f-glow-38: color-mix(in srgb, ${palette.glow} 38%, transparent)`,
-		`--f-glow-20: color-mix(in srgb, ${palette.glow} 20%, transparent)`,
+		// Pre-mixed glow/accent alphas (rgba, no CSS color-mix dependency) so the
+		// whole card renders correctly on older Safari/Chrome.
+		`--p-glow-16: ${hexToRgba(palette.glow, 0.16)}`,
+		`--p-glow-20: ${hexToRgba(palette.glow, 0.2)}`,
+		`--p-glow-22: ${hexToRgba(palette.glow, 0.22)}`,
+		`--p-glow-24: ${hexToRgba(palette.glow, 0.24)}`,
+		`--p-glow-28: ${hexToRgba(palette.glow, 0.28)}`,
+		`--p-glow-32: ${hexToRgba(palette.glow, 0.32)}`,
+		`--p-glow-38: ${hexToRgba(palette.glow, 0.38)}`,
+		`--p-accent-18: ${hexToRgba(palette.accent, 0.18)}`,
+		`--p-accent-22: ${hexToRgba(palette.accent, 0.22)}`,
+		`--p-accent-40: ${hexToRgba(palette.accent, 0.4)}`,
+		// Accent blended toward white (for stripe pattern + ghost-mark tints).
+		`--p-accent-w22: ${mixHex(palette.accent, 0.22)}`,
+		`--p-accent-w42: ${mixHex(palette.accent, 0.42)}`,
+		`--p-accent-w45: ${mixHex(palette.accent, 0.45)}`,
+		`--p-accent-w86: ${mixHex(palette.accent, 0.86)}`,
+		// Aliases kept for frame shadows defined in passportSkins.js.
+		`--f-glow-38: ${hexToRgba(palette.glow, 0.38)}`,
+		`--f-glow-20: ${hexToRgba(palette.glow, 0.2)}`,
 		// Skin axis vars (holo / frame / texture / type) — the modular layer.
 		skin.varString
 	].join('; ');
@@ -303,6 +321,8 @@
 						<span class="fallback-word">PASS</span>
 					</span>
 				{/if}
+				<!-- Tap affordance: only shows on touch devices (no hover to hint it). -->
+				<span class="qr-tap-hint" aria-hidden="true">tap to sync</span>
 			</a>
 		{:else}
 			<div
@@ -351,6 +371,9 @@
 			--f-shadow,
 			0 24px 48px var(--f-glow-38), 0 8px 18px var(--f-glow-20)
 		);
+		/* FRAME drop-shadow (e.g. chunky's hard offset) — composites with the 3D
+		   tilt transform so the toy shadow moves with the card, not flat behind it. */
+		filter: var(--f-filter, none);
 		/* TYPE axis sets the card font. */
 		font-family: var(--t-font, inherit);
 		color: var(--p-ink);
@@ -380,7 +403,7 @@
 			linear-gradient(
 				115deg,
 				transparent 0%,
-				color-mix(in srgb, var(--p-glow) 22%, transparent) 46%,
+				var(--p-glow-22) 46%,
 				transparent 72%
 			);
 		mix-blend-mode: overlay;
@@ -484,7 +507,7 @@
 		letter-spacing: 0.04em;
 		text-transform: uppercase;
 		backdrop-filter: blur(6px);
-		box-shadow: 0 6px 14px color-mix(in srgb, var(--p-glow) 28%, transparent);
+		box-shadow: 0 6px 14px var(--p-glow-28);
 		cursor: pointer;
 		transition:
 			transform 140ms ease,
@@ -548,7 +571,7 @@
 		color: var(--p-ink);
 		text-shadow:
 			0 1px 0 rgba(255, 255, 255, 0.28),
-			0 8px 20px color-mix(in srgb, var(--p-glow) 16%, transparent);
+			0 8px 20px var(--p-glow-16);
 		text-wrap: balance;
 	}
 
@@ -562,7 +585,7 @@
 	.passport-pattern {
 		background: repeating-linear-gradient(
 			135deg,
-			color-mix(in srgb, var(--p-accent) 86%, #fff 14%) 0 5px,
+			var(--p-accent-w86) 0 5px,
 			rgba(255, 255, 255, 0.18) 5px 10px,
 			rgba(255, 255, 255, 0.06) 10px 15px
 		);
@@ -583,7 +606,7 @@
 		background: rgba(255, 255, 255, 0.22);
 		border: 2.5px solid rgba(255, 255, 255, 0.72);
 		box-shadow:
-			0 8px 20px color-mix(in srgb, var(--p-glow) 32%, transparent),
+			0 8px 20px var(--p-glow-32),
 			0 2px 0 rgba(255, 255, 255, 0.52) inset;
 	}
 
@@ -604,7 +627,7 @@
 	.ghost-seal {
 		background: rgba(255, 255, 255, 0.22);
 		border: 2px solid rgba(255, 255, 255, 0.52);
-		box-shadow: 0 6px 14px color-mix(in srgb, var(--p-glow) 24%, transparent);
+		box-shadow: 0 6px 14px var(--p-glow-24);
 	}
 
 	/* =====================================================================
@@ -618,6 +641,9 @@
 		place-items: center;
 		overflow: hidden;
 		position: relative;
+		/* Small safe margin so the -2deg rotation + hover lift never clip against
+		   the card's overflow-hidden rounded edge in the bottom-right corner. */
+		margin: 0.15rem 0.15rem 0 0;
 		rotate: -2deg;
 		border-radius: 1.02rem;
 		border: 2px solid rgba(255, 255, 255, 0.72);
@@ -629,7 +655,7 @@
 			);
 		padding: 0.2rem;
 		box-shadow:
-			0 13px 26px color-mix(in srgb, var(--p-glow) 28%, transparent),
+			0 13px 26px var(--p-glow-28),
 			0 2px 0 rgba(255, 255, 255, 0.72) inset,
 			inset 0 -1px 0 rgba(0, 0, 0, 0.06);
 		transition:
@@ -643,10 +669,10 @@
 		inset: 0.28rem;
 		border-radius: 0.74rem;
 		background:
-			linear-gradient(90deg, color-mix(in srgb, var(--p-accent) 18%, transparent), transparent 42%),
+			linear-gradient(90deg, var(--p-accent-18), transparent 42%),
 			repeating-linear-gradient(
 				135deg,
-				color-mix(in srgb, var(--p-accent) 18%, transparent) 0 3px,
+				var(--p-accent-18) 0 3px,
 				rgba(255, 255, 255, 0) 3px 7px
 			);
 		opacity: 0;
@@ -661,17 +687,17 @@
 
 	.passport-qr-stamp:hover,
 	.passport-qr-stamp:focus-visible {
-		transform: translateY(-2px) scale(1.025) rotate(1deg);
+		transform: translateY(-1px) scale(1.02) rotate(1deg);
 		box-shadow:
-			0 16px 30px color-mix(in srgb, var(--p-glow) 32%, transparent),
+			0 16px 30px var(--p-glow-32),
 			inset 0 1px 0 rgba(255, 255, 255, 0.9);
 		outline: none;
 	}
 
 	.passport-qr-stamp:focus-visible {
 		box-shadow:
-			0 0 0 3px color-mix(in srgb, var(--p-accent) 40%, transparent),
-			0 10px 22px color-mix(in srgb, var(--p-glow) 24%, transparent);
+			0 0 0 3px var(--p-accent-40),
+			0 10px 22px var(--p-glow-24);
 	}
 
 	.passport-qr-stamp img {
@@ -684,6 +710,31 @@
 		object-fit: cover;
 	}
 
+	/* "tap to sync" hint — hidden by default; shown only on touch devices, where
+	   there is no hover to suggest the QR stamp is interactive. */
+	.qr-tap-hint {
+		position: absolute;
+		inset-inline: 0;
+		bottom: 0;
+		z-index: 2;
+		display: none;
+		padding: 0.12rem 0;
+		background: rgba(0, 0, 0, 0.46);
+		color: #fff;
+		font-size: 0.46rem;
+		font-weight: 800;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		text-align: center;
+		pointer-events: none;
+	}
+
+	@media (hover: none) and (pointer: coarse) {
+		.qr-tap-hint {
+			display: block;
+		}
+	}
+
 	.passport-link-fallback {
 		position: relative;
 		z-index: 1;
@@ -694,11 +745,7 @@
 		border-radius: 0.78rem;
 		background:
 			radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.86), transparent 45%),
-			linear-gradient(
-				135deg,
-				rgba(255, 255, 255, 0.9),
-				color-mix(in srgb, var(--p-accent) 22%, rgba(255, 255, 255, 0.7))
-			);
+			linear-gradient(135deg, rgba(255, 255, 255, 0.9), var(--p-accent-w22));
 		color: var(--p-ink);
 	}
 
@@ -709,7 +756,7 @@
 		height: 1.75rem;
 		border-radius: 999px 999px 0.72rem 0.72rem;
 		background: var(--p-accent);
-		filter: drop-shadow(0 3px 0 color-mix(in srgb, var(--p-accent) 45%, #fff));
+		filter: drop-shadow(0 3px 0 var(--p-accent-w45));
 	}
 
 	.fallback-ghost::before,
@@ -743,7 +790,7 @@
 		width: 32px;
 		height: 36px;
 		fill: rgba(255, 255, 255, 0.92);
-		filter: drop-shadow(0 3px 0 color-mix(in srgb, var(--p-accent) 42%, #fff));
+		filter: drop-shadow(0 3px 0 var(--p-accent-w42));
 	}
 
 	.ghost-mark circle {

--- a/src/lib/cartridges/MembershipCard.svelte
+++ b/src/lib/cartridges/MembershipCard.svelte
@@ -35,16 +35,14 @@
 	let gyroSupported = false;
 	let gyroEnabled = false;
 	let removeGyroListener = null;
+	// Honour prefers-reduced-motion: no parallax tilt, no gyroscope.
+	let reducedMotion = false;
 
 	const clamp = (value, min = 0, max = 100) => Math.min(max, Math.max(min, value));
 
-	// Distance of the pointer from the card centre, normalised 0..1 — drives
-	// how strongly the foil/glare bloom so the effect is calm at rest.
-	$: pointerFromCenter = clamp(
-		Math.sqrt((mouseY - 50) * (mouseY - 50) + (mouseX - 50) * (mouseX - 50)) / 50,
-		0,
-		1
-	);
+	// --hovered drives the foil/glare bloom ceiling + the idle-drift stop. It
+	// changes outside pointer moves (enter/leave, gyro), so write it reactively.
+	$: if (cardEl) cardEl.style.setProperty('--hovered', isHovered || gyroEnabled ? '1' : '0');
 
 	$: identity = generateMemberIdentity(vaultHash);
 	$: hasVaultHash = !identity.isFallback;
@@ -62,8 +60,11 @@
 	$: inkColor = isDarkSubstrate ? '#e8fff0' : palette.ink;
 	$: inkSoftColor = isDarkSubstrate ? 'rgba(232, 255, 240, 0.66)' : palette.inkSoft;
 
+	// STATIC style: palette + skin vars. These change only when the supporter /
+	// skin changes, so they live on the inline style attribute. The per-frame
+	// pointer vars are written directly to cardEl.style in commitPointer() to
+	// avoid rebuilding this ~1kb string 60×/sec while the pointer moves.
 	$: cardStyle = [
-		// Palette vars — drive the colour layer.
 		`--p-bg-1: ${palette.bg[0]}`,
 		`--p-bg-2: ${palette.bg[1]}`,
 		`--p-bg-3: ${palette.bg[2] || palette.bg[1]}`,
@@ -75,17 +76,7 @@
 		`--f-glow-38: color-mix(in srgb, ${palette.glow} 38%, transparent)`,
 		`--f-glow-20: color-mix(in srgb, ${palette.glow} 20%, transparent)`,
 		// Skin axis vars (holo / frame / texture / type) — the modular layer.
-		skin.varString,
-		// Pointer / holo motion vars.
-		`--mx: ${mouseX}%`,
-		`--my: ${mouseY}%`,
-		`--pointer-x: ${mouseX}%`,
-		`--pointer-y: ${mouseY}%`,
-		// Parallax anchors for the shine gradient (kept near centre so it drifts gently).
-		`--bg-x: ${50 + (mouseX - 50) * 0.5}%`,
-		`--bg-y: ${50 + (mouseY - 50) * 0.5}%`,
-		`--from-center: ${pointerFromCenter}`,
-		`--hovered: ${isHovered || gyroEnabled ? 1 : 0}`
+		skin.varString
 	].join('; ');
 	$: effectivePassportCode = passportCode || storedPassportCode;
 	$: passportSyncUrl =
@@ -104,11 +95,26 @@
 		qrHasFailed = false;
 	}
 
+	// Write the per-frame pointer CSS vars straight onto the element. Avoids
+	// rebuilding the full inline-style string (and a setAttribute flush) 60×/sec.
+	function writePointerVars(x, y) {
+		if (!cardEl) return;
+		const s = cardEl.style;
+		s.setProperty('--mx', `${x}%`);
+		s.setProperty('--my', `${y}%`);
+		s.setProperty('--pointer-x', `${x}%`);
+		s.setProperty('--pointer-y', `${y}%`);
+		s.setProperty('--bg-x', `${50 + (x - 50) * 0.5}%`);
+		s.setProperty('--bg-y', `${50 + (y - 50) * 0.5}%`);
+		s.setProperty('--from-center', `${clamp(Math.hypot(y - 50, x - 50) / 50, 0, 1)}`);
+	}
+
 	// Push the latest pointer position once per animation frame.
 	function commitPointer() {
 		rafId = null;
 		mouseX = pendingX;
 		mouseY = pendingY;
+		writePointerVars(mouseX, mouseY);
 	}
 
 	function schedulePointer(x, y) {
@@ -167,6 +173,16 @@
 		storedPassportCode = readStoredSupporterCode();
 		storedVaultUrl = readStoredVaultServerUrl();
 
+		// Seed the per-frame pointer vars at centre so the foil starts calm.
+		writePointerVars(50, 50);
+
+		// Respect reduced-motion: skip the parallax tilt and never offer gyro.
+		reducedMotion =
+			typeof window !== 'undefined' &&
+			window.matchMedia &&
+			window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reducedMotion) return cleanup;
+
 		// Coarse pointer (touch) + a motion sensor present → offer tilt.
 		const hasMotion = typeof window !== 'undefined' && 'DeviceOrientationEvent' in window;
 		const isTouch =
@@ -180,17 +196,20 @@
 			gyroSupported && typeof DeviceOrientationEvent.requestPermission === 'function';
 		if (gyroSupported && !needsPermission) attachGyro();
 
-		return () => {
-			if (rafId !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId);
-			if (removeGyroListener) removeGyroListener();
-		};
+		return cleanup;
 	});
+
+	function cleanup() {
+		if (rafId !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId);
+		if (removeGyroListener) removeGyroListener();
+	}
 </script>
 
 <div
 	bind:this={cardEl}
 	class="passport-card relative flex aspect-[1.586/1] w-full max-w-[342px] flex-col justify-between overflow-hidden p-5"
 	class:is-placeholder={!hasVaultHash}
+	class:reduced-motion={reducedMotion}
 	style={cardStyle}
 	role="group"
 	aria-label={hasVaultHash
@@ -308,6 +327,15 @@
 	   A soft top-left white bloom keeps a premium lit-from-within feel.
 	   ===================================================================== */
 	.passport-card {
+		/* Pointer-var defaults so first paint (pre-mount/SSR) is valid + centred. */
+		--mx: 50%;
+		--my: 50%;
+		--pointer-x: 50%;
+		--pointer-y: 50%;
+		--bg-x: 50%;
+		--bg-y: 50%;
+		--from-center: 0;
+		--hovered: 0;
 		/* FRAME axis drives border/radius/shadow; defaults match the soft skin. */
 		border-radius: var(--f-radius, 1.55rem);
 		background:
@@ -321,7 +349,7 @@
 		border: var(--f-border, 2px solid rgba(255, 255, 255, 0.38));
 		box-shadow: var(
 			--f-shadow,
-			0 24px 48px var(--f-glow-38) 0 8px 18px var(--f-glow-20)
+			0 24px 48px var(--f-glow-38), 0 8px 18px var(--f-glow-20)
 		);
 		/* TYPE axis sets the card font. */
 		font-family: var(--t-font, inherit);
@@ -360,13 +388,8 @@
 	}
 
 	/*
-	  HOLOFOIL — pointer-tracked rainbow sheen. Physics UNCHANGED.
-	  Technique adapted from simeydotme/pokemon-cards-css (MIT).
-	  Full spectral saturation + color-dodge blend for lush iridescent sheen
-	  on the saturated card base. The scanline sub-layer adds fine foil texture.
-	*/
-	/*
 	  HOLOFOIL — pointer-tracked iridescent sheen, fully driven by the HOLO axis.
+	  Technique adapted from simeydotme/pokemon-cards-css (MIT).
 	  Spectral stops (--holo-c1..6), sweep angle/size, blend mode, filter and
 	  opacity envelope all come from the active skin. A radial "reveal" mask
 	  centred on the pointer makes the foil BRIGHTEST where you point — so the
@@ -444,14 +467,19 @@
 		border-radius: inherit;
 	}
 
-	/* Mobile-only affordance to opt into gyroscope tilt (iOS permission gate). */
+	/* Mobile-only affordance to opt into gyroscope tilt (iOS permission gate).
+	   Sized to a >=44px tap target — it unlocks the whole gyro experience. */
 	.tilt-toggle {
-		padding: 0.28rem 0.62rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 44px;
+		padding: 0 1rem;
 		border-radius: 999px;
 		border: 2px solid rgba(255, 255, 255, 0.72);
 		background: rgba(255, 255, 255, 0.22);
 		color: var(--p-ink);
-		font-size: 0.6rem;
+		font-size: 0.7rem;
 		font-weight: 900;
 		letter-spacing: 0.04em;
 		text-transform: uppercase;
@@ -752,6 +780,8 @@
 	}
 
 	.passport-card:not(.is-placeholder) {
+		/* GPU hint: this element re-composites every pointer frame. */
+		will-change: transform;
 		transition:
 			transform 160ms ease,
 			box-shadow 120ms ease;
@@ -759,26 +789,33 @@
 			rotateY(calc((var(--mx) - 50) * 0.12deg));
 	}
 
+	/* Reduced-motion: keep depth but drop the pointer-following parallax tilt. */
+	.passport-card.reduced-motion:not(.is-placeholder) {
+		will-change: auto;
+		transform: perspective(620px);
+	}
+
+	/* Keep perspective() in both keyframes so handing off to the resting tilt
+	   transform (also perspective-based) doesn't pop. */
 	@keyframes passportReveal {
 		from {
 			opacity: 0;
-			transform: translateY(10px) scale(0.94) rotate(-1deg);
+			transform: perspective(620px) translateY(10px) scale(0.94) rotate(-1deg);
 		}
 		to {
 			opacity: 1;
-			transform: translateY(0) scale(1) rotate(0);
+			transform: perspective(620px) translateY(0) scale(1) rotate(0);
 		}
 	}
 
-	/* Idle shimmer: gently drift the spectral rainbow so the card breathes at
-	   rest. Position-only — the per-skin filter is left untouched so each holo
-	   keeps its own look. */
+	/* Idle shimmer: gently drift the spectral rainbow on a slight diagonal so the
+	   card breathes at rest. Position-only — the per-skin filter is untouched. */
 	@keyframes foilDrift {
 		0% {
-			background-position: 0% 50%;
+			background-position: 0% 35%;
 		}
 		100% {
-			background-position: 100% 50%;
+			background-position: 100% 65%;
 		}
 	}
 </style>

--- a/src/lib/cartridges/MembershipCard.svelte
+++ b/src/lib/cartridges/MembershipCard.svelte
@@ -1,6 +1,8 @@
 <script>
 	import { onMount } from 'svelte';
 	import { generateMemberIdentity } from './identityUtils.js';
+	import { buildPassportAvatar } from './passportAvatar.js';
+	import { selectSkin, selectNamedSkin } from './passportSkins.js';
 	import { buildPassportSyncUrl, getVaultHandshakeQR } from '$lib/services/qrHandshakeService.js';
 	import {
 		readStoredSupporterCode,
@@ -9,10 +11,14 @@
 
 	export let vaultHash = '';
 	export let passportCode = '';
+	// Optional: force a named skin (e.g. 'hacker') for preview/dev. When unset,
+	// the skin is derived deterministically from the vault hash.
+	export let skinName = '';
 
 	let storedPassportCode = '';
 	let storedVaultUrl = '';
 	let cardEl;
+	// Pointer-driven holofoil state (0-100 across the card face).
 	let mouseX = 50;
 	let mouseY = 50;
 	let isHovered = false;
@@ -20,14 +26,66 @@
 	let qrHasFailed = false;
 	let previousQrImageUrl = '';
 
+	// rAF throttle so we only touch the DOM once per frame while moving.
+	let rafId = null;
+	let pendingX = 50;
+	let pendingY = 50;
+
+	// Gyroscope (mobile tilt) state.
+	let gyroSupported = false;
+	let gyroEnabled = false;
+	let removeGyroListener = null;
+
+	const clamp = (value, min = 0, max = 100) => Math.min(max, Math.max(min, value));
+
+	// Distance of the pointer from the card centre, normalised 0..1 — drives
+	// how strongly the foil/glare bloom so the effect is calm at rest.
+	$: pointerFromCenter = clamp(
+		Math.sqrt((mouseY - 50) * (mouseY - 50) + (mouseX - 50) * (mouseX - 50)) / 50,
+		0,
+		1
+	);
+
 	$: identity = generateMemberIdentity(vaultHash);
 	$: hasVaultHash = !identity.isFallback;
+
+	// Skin = one coordinate in the modular axis space (holo/frame/texture/type/
+	// avatar) + palette. Deterministic from the hash, or forced via skinName.
+	$: skin = skinName
+		? selectNamedSkin(skinName, vaultHash)
+		: selectSkin(vaultHash);
+	$: palette = skin.palette;
+	$: avatarUri = buildPassportAvatar(vaultHash || 'talktype', skin.avatarStyle);
+
+	// Dark-substrate frames (terminal) force light ink so text stays legible.
+	$: isDarkSubstrate = skin.choices.frame === 'terminal';
+	$: inkColor = isDarkSubstrate ? '#e8fff0' : palette.ink;
+	$: inkSoftColor = isDarkSubstrate ? 'rgba(232, 255, 240, 0.66)' : palette.inkSoft;
+
 	$: cardStyle = [
-		`--passport-bg: #${identity.bg}`,
-		`--passport-shape: #${identity.shape}`,
+		// Palette vars — drive the colour layer.
+		`--p-bg-1: ${palette.bg[0]}`,
+		`--p-bg-2: ${palette.bg[1]}`,
+		`--p-bg-3: ${palette.bg[2] || palette.bg[1]}`,
+		`--p-accent: ${palette.accent}`,
+		`--p-ink: ${inkColor}`,
+		`--p-ink-soft: ${inkSoftColor}`,
+		`--p-glow: ${palette.glow}`,
+		// Pre-mixed glow alphas so frame shadows can reference them simply.
+		`--f-glow-38: color-mix(in srgb, ${palette.glow} 38%, transparent)`,
+		`--f-glow-20: color-mix(in srgb, ${palette.glow} 20%, transparent)`,
+		// Skin axis vars (holo / frame / texture / type) — the modular layer.
+		skin.varString,
+		// Pointer / holo motion vars.
 		`--mx: ${mouseX}%`,
 		`--my: ${mouseY}%`,
-		`--hovered: ${isHovered ? 1 : 0}`
+		`--pointer-x: ${mouseX}%`,
+		`--pointer-y: ${mouseY}%`,
+		// Parallax anchors for the shine gradient (kept near centre so it drifts gently).
+		`--bg-x: ${50 + (mouseX - 50) * 0.5}%`,
+		`--bg-y: ${50 + (mouseY - 50) * 0.5}%`,
+		`--from-center: ${pointerFromCenter}`,
+		`--hovered: ${isHovered || gyroEnabled ? 1 : 0}`
 	].join('; ');
 	$: effectivePassportCode = passportCode || storedPassportCode;
 	$: passportSyncUrl =
@@ -46,40 +104,124 @@
 		qrHasFailed = false;
 	}
 
-	function handleMouseMove(e) {
+	// Push the latest pointer position once per animation frame.
+	function commitPointer() {
+		rafId = null;
+		mouseX = pendingX;
+		mouseY = pendingY;
+	}
+
+	function schedulePointer(x, y) {
+		pendingX = clamp(x);
+		pendingY = clamp(y);
+		if (rafId === null && typeof requestAnimationFrame === 'function') {
+			rafId = requestAnimationFrame(commitPointer);
+		}
+	}
+
+	function handlePointerMove(e) {
+		if (!cardEl) return;
 		const rect = cardEl.getBoundingClientRect();
-		mouseX = ((e.clientX - rect.left) / rect.width) * 100;
-		mouseY = ((e.clientY - rect.top) / rect.height) * 100;
+		schedulePointer(
+			((e.clientX - rect.left) / rect.width) * 100,
+			((e.clientY - rect.top) / rect.height) * 100
+		);
+	}
+
+	function settleToCenter() {
+		isHovered = false;
+		schedulePointer(50, 50);
+	}
+
+	// Map device tilt (gamma = left/right, beta = front/back) onto the same
+	// 0-100 pointer space the mouse uses, clamped so it never pins to an edge.
+	function handleOrientation(event) {
+		const gamma = event.gamma ?? 0; // -90..90
+		const beta = event.beta ?? 0; // -180..180
+		schedulePointer(50 + clamp(gamma, -35, 35) * (50 / 35), 50 + clamp(beta - 45, -35, 35) * (50 / 35));
+	}
+
+	function attachGyro() {
+		window.addEventListener('deviceorientation', handleOrientation, true);
+		gyroEnabled = true;
+		removeGyroListener = () =>
+			window.removeEventListener('deviceorientation', handleOrientation, true);
+	}
+
+	// iOS 13+ needs an explicit permission request triggered by a user gesture.
+	async function enableGyro() {
+		const evt = typeof DeviceOrientationEvent !== 'undefined' ? DeviceOrientationEvent : null;
+		if (!evt) return;
+		try {
+			if (typeof evt.requestPermission === 'function') {
+				const state = await evt.requestPermission();
+				if (state !== 'granted') return;
+			}
+			attachGyro();
+		} catch (error) {
+			console.warn('Passport tilt permission denied:', error);
+		}
 	}
 
 	onMount(() => {
 		storedPassportCode = readStoredSupporterCode();
 		storedVaultUrl = readStoredVaultServerUrl();
+
+		// Coarse pointer (touch) + a motion sensor present → offer tilt.
+		const hasMotion = typeof window !== 'undefined' && 'DeviceOrientationEvent' in window;
+		const isTouch =
+			typeof window !== 'undefined' &&
+			window.matchMedia &&
+			window.matchMedia('(pointer: coarse)').matches;
+		gyroSupported = hasMotion && isTouch;
+
+		// Android exposes orientation without a permission gate — wire it up now.
+		const needsPermission =
+			gyroSupported && typeof DeviceOrientationEvent.requestPermission === 'function';
+		if (gyroSupported && !needsPermission) attachGyro();
+
+		return () => {
+			if (rafId !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId);
+			if (removeGyroListener) removeGyroListener();
+		};
 	});
 </script>
 
 <div
 	bind:this={cardEl}
-	class="passport-card relative flex aspect-[1.586/1] w-full max-w-[342px] flex-col justify-between overflow-hidden rounded-[1.55rem] border border-[#fffdf0]/80 p-5 text-gray-900"
+	class="passport-card relative flex aspect-[1.586/1] w-full max-w-[342px] flex-col justify-between overflow-hidden p-5"
 	class:is-placeholder={!hasVaultHash}
 	style={cardStyle}
 	role="group"
 	aria-label={hasVaultHash
 		? `TalkType supporter passport for ${identity.name}`
 		: 'TalkType supporter passport placeholder'}
-	on:mousemove={handleMouseMove}
-	on:mouseenter={() => (isHovered = true)}
-	on:mouseleave={() => (isHovered = false)}
+	on:pointermove={handlePointerMove}
+	on:pointerenter={() => (isHovered = true)}
+	on:pointerleave={settleToCenter}
 >
+	<div class="passport-substrate pointer-events-none absolute inset-0"></div>
 	<div class="passport-glow pointer-events-none absolute inset-0"></div>
 	<div class="holofoil pointer-events-none absolute inset-0"></div>
+	<div class="passport-glare pointer-events-none absolute inset-0"></div>
+	<div class="passport-texture pointer-events-none absolute inset-0"></div>
 	<div class="passport-laminate pointer-events-none absolute inset-0"></div>
 	<div class="passport-pattern pointer-events-none absolute right-0 top-0 h-full w-28"></div>
 	<div class="passport-edge pointer-events-none absolute inset-0"></div>
 
+	{#if gyroSupported && !gyroEnabled}
+		<button
+			type="button"
+			class="tilt-toggle absolute bottom-2 left-1/2 z-20 -translate-x-1/2"
+			on:click|stopPropagation={enableGyro}
+		>
+			✦ tap for tilt
+		</button>
+	{/if}
+
 	<div class="relative z-10 flex items-start justify-between gap-3">
 		<div class="min-w-0">
-			<h3 class="passport-kicker text-[11px] font-black uppercase text-gray-600">
+			<h3 class="passport-kicker text-[11px] font-black uppercase">
 				TalkType Passport
 			</h3>
 			<p class="passport-name mt-1 max-w-[190px] font-black">
@@ -87,18 +229,28 @@
 			</p>
 		</div>
 
+		<!-- Avatar chip: DiceBear SVG with initials fallback -->
 		<div
-			class="initials-chip grid h-14 w-14 shrink-0 place-items-center rounded-2xl font-black text-gray-800"
+			class="avatar-chip grid h-14 w-14 shrink-0 place-items-center rounded-2xl font-black overflow-hidden"
 			aria-hidden="true"
 		>
-			{identity.initials}
+			{#if avatarUri}
+				<img
+					src={avatarUri}
+					alt=""
+					class="avatar-img h-full w-full object-cover"
+					draggable="false"
+				/>
+			{:else}
+				<span class="avatar-initials">{identity.initials}</span>
+			{/if}
 		</div>
 	</div>
 
 	<div class="relative z-10 flex items-end justify-between gap-4">
 		<div class="min-w-0">
-			<p class="passport-label text-[10px] font-bold uppercase text-gray-600">Supporter ID</p>
-			<p class="mt-1 font-mono text-sm font-black tracking-normal">{identity.memberId}</p>
+			<p class="passport-label text-[10px] font-bold uppercase">Supporter ID</p>
+			<p class="mt-1 font-mono text-sm font-black tracking-normal passport-member-id">{identity.memberId}</p>
 			{#if hasVaultHash && identity.phrase}
 				<p class="passport-phrase mt-1 italic">{identity.phrase}</p>
 			{/if}
@@ -151,16 +303,29 @@
 </div>
 
 <style>
+	/* =====================================================================
+	   CARD BASE — Saturated multi-stop diagonal gradient using palette vars.
+	   A soft top-left white bloom keeps a premium lit-from-within feel.
+	   ===================================================================== */
 	.passport-card {
+		/* FRAME axis drives border/radius/shadow; defaults match the soft skin. */
+		border-radius: var(--f-radius, 1.55rem);
 		background:
-			radial-gradient(circle at 18% 18%, rgba(255, 255, 255, 0.58), transparent 34%),
-			linear-gradient(135deg, rgba(255, 253, 240, 0.88), rgba(255, 253, 240, 0.18) 48%),
-			linear-gradient(135deg, var(--passport-bg) 0%, #fff6df 74%, #f9d8b6 100%);
-		box-shadow:
-			0 24px 46px rgba(136, 82, 88, 0.22),
-			0 8px 18px rgba(236, 72, 153, 0.1),
-			0 3px 0 rgba(255, 253, 240, 0.9) inset,
-			0 0 0 1px rgba(136, 82, 88, 0.08);
+			radial-gradient(circle at 12% 14%, rgba(255, 255, 255, 0.32), transparent 38%),
+			linear-gradient(
+				135deg,
+				var(--p-bg-1) 0%,
+				var(--p-bg-2) 48%,
+				var(--p-bg-3) 100%
+			);
+		border: var(--f-border, 2px solid rgba(255, 255, 255, 0.38));
+		box-shadow: var(
+			--f-shadow,
+			0 24px 48px var(--f-glow-38) 0 8px 18px var(--f-glow-20)
+		);
+		/* TYPE axis sets the card font. */
+		font-family: var(--t-font, inherit);
+		color: var(--p-ink);
 		transform-origin: center;
 		isolation: isolate;
 	}
@@ -170,38 +335,137 @@
 		box-shadow: 0 14px 32px rgba(79, 70, 68, 0.08);
 	}
 
-	.passport-glow {
-		background:
-			radial-gradient(circle at 18% 22%, rgba(255, 253, 240, 0.62), transparent 32%),
-			linear-gradient(115deg, transparent 0%, rgba(255, 253, 240, 0.54) 46%, transparent 72%);
-		mix-blend-mode: overlay;
-		opacity: 0.46;
+	/* SUBSTRATE — FRAME-axis tint over the palette gradient. Transparent for
+	   light frames; a dark wash for terminal so "hacker" reads dark on any
+	   palette while the holo still picks up the palette's accent colours. */
+	.passport-substrate {
+		background: var(--f-substrate, transparent);
+		border-radius: inherit;
 	}
 
+	/* =====================================================================
+	   GLOW — tinted bloom using palette glow colour instead of fixed cream.
+	   ===================================================================== */
+	.passport-glow {
+		background:
+			radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.44), transparent 32%),
+			linear-gradient(
+				115deg,
+				transparent 0%,
+				color-mix(in srgb, var(--p-glow) 22%, transparent) 46%,
+				transparent 72%
+			);
+		mix-blend-mode: overlay;
+		opacity: 0.52;
+	}
+
+	/*
+	  HOLOFOIL — pointer-tracked rainbow sheen. Physics UNCHANGED.
+	  Technique adapted from simeydotme/pokemon-cards-css (MIT).
+	  Full spectral saturation + color-dodge blend for lush iridescent sheen
+	  on the saturated card base. The scanline sub-layer adds fine foil texture.
+	*/
+	/*
+	  HOLOFOIL — pointer-tracked iridescent sheen, fully driven by the HOLO axis.
+	  Spectral stops (--holo-c1..6), sweep angle/size, blend mode, filter and
+	  opacity envelope all come from the active skin. A radial "reveal" mask
+	  centred on the pointer makes the foil BRIGHTEST where you point — so the
+	  light intensifies the holo instead of painting a white dot over it.
+	*/
 	.holofoil {
 		background:
-			linear-gradient(
-				112deg,
-				transparent 0%,
-				transparent 22%,
-				rgba(111, 211, 255, 0.16) 34%,
-				rgba(255, 129, 214, 0.18) 47%,
-				rgba(255, 224, 130, 0.16) 60%,
-				transparent 76%
-			),
-			radial-gradient(
-				ellipse at 76% 28%,
-				rgba(116, 215, 255, 0.24) 0%,
-				rgba(255, 134, 210, 0.16) 35%,
-				transparent 66%
-			),
-			linear-gradient(28deg, transparent 8%, rgba(255, 255, 255, 0.16) 34%, transparent 54%);
-		mix-blend-mode: normal;
-		opacity: calc(0.28 + (var(--hovered) * 0.24));
-		transition: opacity 260ms ease;
+			/* Drifting spectral rainbow — parallaxes against pointer via --bg-x/--bg-y. */
+			repeating-linear-gradient(
+				var(--holo-angle, 110deg),
+				var(--holo-c1) 0%,
+				var(--holo-c2) 14%,
+				var(--holo-c3) 28%,
+				var(--holo-c4) 42%,
+				var(--holo-c5) 56%,
+				var(--holo-c6) 70%,
+				var(--holo-c1) 84%
+			);
+		background-size: var(--holo-size, 400% 400%);
+		background-position: var(--bg-x) var(--bg-y);
+		mix-blend-mode: var(--holo-blend, color-dodge);
+		filter: var(--holo-filter, brightness(0.9) contrast(1.4) saturate(1.6));
+		/* Reveal mask: foil is fully present near the pointer and fades toward
+		   the far edges, so movement sweeps a lit band across the card. */
+		-webkit-mask-image: radial-gradient(
+			farthest-corner circle at var(--pointer-x) var(--pointer-y),
+			rgba(0, 0, 0, 1) 0%,
+			rgba(0, 0, 0, 0.85) 30%,
+			rgba(0, 0, 0, 0.5) 65%,
+			rgba(0, 0, 0, 0.28) 100%
+		);
+		mask-image: radial-gradient(
+			farthest-corner circle at var(--pointer-x) var(--pointer-y),
+			rgba(0, 0, 0, 1) 0%,
+			rgba(0, 0, 0, 0.85) 30%,
+			rgba(0, 0, 0, 0.5) 65%,
+			rgba(0, 0, 0, 0.28) 100%
+		);
+		/* Calm at rest, blooms with pointer distance + hover. Floor/gain per skin.
+		   The pointer mask already concentrates the foil, so the envelope can sit
+		   high without the old "white dot" problem. */
+		opacity: calc(
+			var(--holo-rest, 0.26) + (var(--from-center) * var(--holo-bloom, 0.5)) +
+				(var(--hovered) * 0.34)
+		);
+		transition: opacity 280ms ease;
 		border-radius: inherit;
-		clip-path: polygon(62% 0, 100% 0, 100% 100%, 55% 100%);
-		filter: saturate(1.02);
+	}
+
+	/*
+	  GLARE — a SOFT, wide sheen, not a hard hotspot. It widens the lit area and
+	  adds gentle dimensional gloss that follows the pointer, but uses a low
+	  white ceiling + soft-light blend so it lifts the foil's colour rather than
+	  bleaching a point of light over it.
+	*/
+	.passport-glare {
+		background: radial-gradient(
+			farthest-corner ellipse at var(--pointer-x) var(--pointer-y),
+			rgba(255, 255, 255, 0.34) 0%,
+			rgba(255, 255, 255, 0.12) 32%,
+			transparent 68%
+		);
+		mix-blend-mode: soft-light;
+		opacity: calc(0.18 + (var(--from-center) * 0.3) + (var(--hovered) * 0.28));
+		transition: opacity 220ms ease;
+		border-radius: inherit;
+	}
+
+	/* TEXTURE axis — surface grain/scanlines/halftone/sparkle overlay. */
+	.passport-texture {
+		background-image: var(--tx-image, none);
+		background-size: var(--tx-size, auto);
+		mix-blend-mode: var(--tx-blend, normal);
+		opacity: var(--tx-opacity, 0);
+		border-radius: inherit;
+	}
+
+	/* Mobile-only affordance to opt into gyroscope tilt (iOS permission gate). */
+	.tilt-toggle {
+		padding: 0.28rem 0.62rem;
+		border-radius: 999px;
+		border: 2px solid rgba(255, 255, 255, 0.72);
+		background: rgba(255, 255, 255, 0.22);
+		color: var(--p-ink);
+		font-size: 0.6rem;
+		font-weight: 900;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		backdrop-filter: blur(6px);
+		box-shadow: 0 6px 14px color-mix(in srgb, var(--p-glow) 28%, transparent);
+		cursor: pointer;
+		transition:
+			transform 140ms ease,
+			background 140ms ease;
+	}
+
+	.tilt-toggle:active {
+		transform: translate(-50%, 0) scale(0.96);
+		background: rgba(255, 255, 255, 0.38);
 	}
 
 	.passport-laminate {
@@ -221,69 +485,103 @@
 	.passport-edge {
 		border-radius: inherit;
 		box-shadow:
-			inset 0 0 0 1px rgba(255, 253, 240, 0.88),
-			inset 0 -1px 0 rgba(136, 82, 88, 0.12),
+			inset 0 0 0 1px rgba(255, 255, 255, 0.62),
+			inset 0 -1px 0 rgba(0, 0, 0, 0.1),
 			inset 0 1px 0 rgba(255, 255, 255, 0.86);
 	}
 
+	/* =====================================================================
+	   TEXT — palette ink vars replace hardcoded grays.
+	   ===================================================================== */
 	.passport-kicker,
 	.passport-label {
 		letter-spacing: 0;
+		color: var(--p-ink-soft);
 	}
 
 	.passport-phrase {
 		font-size: 0.64rem;
 		line-height: 1.3;
-		color: rgba(55, 65, 81, 0.62);
+		color: var(--p-ink-soft);
 		max-width: 160px;
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 	}
 
+	.passport-name {
+		/* TYPE axis drives size/weight/casing/tracking. */
+		font-size: var(--t-name-size, 1.56rem);
+		font-weight: var(--t-name-weight, 900);
+		text-transform: var(--t-transform, none);
+		letter-spacing: var(--t-tracking, 0);
+		line-height: 1.08;
+		overflow-wrap: break-word;
+		color: var(--p-ink);
+		text-shadow:
+			0 1px 0 rgba(255, 255, 255, 0.28),
+			0 8px 20px color-mix(in srgb, var(--p-glow) 16%, transparent);
+		text-wrap: balance;
+	}
+
+	.passport-member-id {
+		color: var(--p-ink);
+	}
+
+	/* =====================================================================
+	   PATTERN — diagonal stripe band using palette accent colour.
+	   ===================================================================== */
 	.passport-pattern {
 		background: repeating-linear-gradient(
 			135deg,
-			color-mix(in srgb, var(--passport-shape) 86%, #f5c86b 14%) 0 5px,
-			rgba(255, 253, 240, 0.7) 5px 10px,
-			rgba(255, 253, 240, 0.2) 10px 15px
+			color-mix(in srgb, var(--p-accent) 86%, #fff 14%) 0 5px,
+			rgba(255, 255, 255, 0.18) 5px 10px,
+			rgba(255, 255, 255, 0.06) 10px 15px
 		);
 		clip-path: polygon(24% 0, 100% 0, 100% 100%, 0 100%);
-		opacity: 0.86;
-		filter: saturate(1.08);
+		opacity: 0.72;
+		filter: saturate(1.12);
 	}
 
 	.passport-card.is-placeholder .passport-pattern {
 		opacity: 0.24;
 	}
 
-	.passport-name {
-		font-size: 1.56rem;
-		line-height: 1.08;
-		overflow-wrap: break-word;
-		color: #151827;
-		text-shadow:
-			0 1px 0 rgba(255, 253, 240, 0.72),
-			0 8px 20px rgba(136, 82, 88, 0.08);
-		text-wrap: balance;
-	}
-
-	.initials-chip {
-		background:
-			linear-gradient(135deg, rgba(255, 255, 255, 0.68), rgba(255, 253, 240, 0.16)),
-			color-mix(in srgb, var(--passport-shape) 26%, #fffdf0 74%);
-		border: 1px solid rgba(255, 253, 240, 0.94);
+	/* =====================================================================
+	   AVATAR CHIP — DiceBear avatar replaces plain initials text.
+	   Chunky border, hard-ish shadow, pastel-punk energy.
+	   ===================================================================== */
+	.avatar-chip {
+		background: rgba(255, 255, 255, 0.22);
+		border: 2.5px solid rgba(255, 255, 255, 0.72);
 		box-shadow:
-			0 10px 24px rgba(136, 82, 88, 0.16),
-			inset 0 1px 0 rgba(255, 253, 240, 0.72);
+			0 8px 20px color-mix(in srgb, var(--p-glow) 32%, transparent),
+			0 2px 0 rgba(255, 255, 255, 0.52) inset;
 	}
 
+	.avatar-img {
+		border-radius: inherit;
+	}
+
+	.avatar-initials {
+		font-size: 1.1rem;
+		font-weight: 900;
+		color: var(--p-ink);
+		text-shadow: 0 1px 0 rgba(255, 255, 255, 0.3);
+	}
+
+	/* =====================================================================
+	   GHOST SEAL — uses palette accent + glow instead of fixed cream.
+	   ===================================================================== */
 	.ghost-seal {
-		background: rgba(255, 253, 240, 0.62);
-		border: 1px solid rgba(255, 253, 240, 0.78);
-		box-shadow: 0 6px 14px rgba(79, 70, 68, 0.1);
+		background: rgba(255, 255, 255, 0.22);
+		border: 2px solid rgba(255, 255, 255, 0.52);
+		box-shadow: 0 6px 14px color-mix(in srgb, var(--p-glow) 24%, transparent);
 	}
 
+	/* =====================================================================
+	   QR STAMP — palette-tinted background, preserved interaction physics.
+	   ===================================================================== */
 	.passport-qr-stamp {
 		display: grid;
 		width: 4.1rem;
@@ -294,14 +592,18 @@
 		position: relative;
 		rotate: -2deg;
 		border-radius: 1.02rem;
-		border: 1px solid rgba(255, 253, 240, 0.94);
+		border: 2px solid rgba(255, 255, 255, 0.72);
 		background:
-			linear-gradient(135deg, rgba(255, 253, 240, 0.94), rgba(255, 246, 223, 0.88)), #fffdf0;
+			linear-gradient(
+				135deg,
+				rgba(255, 255, 255, 0.88),
+				rgba(255, 255, 255, 0.72)
+			);
 		padding: 0.2rem;
 		box-shadow:
-			0 13px 26px rgba(136, 82, 88, 0.18),
-			0 2px 0 rgba(255, 253, 240, 0.9) inset,
-			inset 0 -1px 0 rgba(136, 82, 88, 0.08);
+			0 13px 26px color-mix(in srgb, var(--p-glow) 28%, transparent),
+			0 2px 0 rgba(255, 255, 255, 0.72) inset,
+			inset 0 -1px 0 rgba(0, 0, 0, 0.06);
 		transition:
 			transform 150ms ease,
 			box-shadow 150ms ease;
@@ -313,11 +615,11 @@
 		inset: 0.28rem;
 		border-radius: 0.74rem;
 		background:
-			linear-gradient(90deg, rgba(236, 72, 153, 0.12), transparent 42%),
+			linear-gradient(90deg, color-mix(in srgb, var(--p-accent) 18%, transparent), transparent 42%),
 			repeating-linear-gradient(
 				135deg,
-				rgba(236, 72, 153, 0.12) 0 3px,
-				rgba(255, 253, 240, 0) 3px 7px
+				color-mix(in srgb, var(--p-accent) 18%, transparent) 0 3px,
+				rgba(255, 255, 255, 0) 3px 7px
 			);
 		opacity: 0;
 		transition: opacity 160ms ease;
@@ -333,15 +635,15 @@
 	.passport-qr-stamp:focus-visible {
 		transform: translateY(-2px) scale(1.025) rotate(1deg);
 		box-shadow:
-			0 16px 30px rgba(136, 82, 88, 0.2),
-			inset 0 1px 0 rgba(255, 253, 240, 0.9);
+			0 16px 30px color-mix(in srgb, var(--p-glow) 32%, transparent),
+			inset 0 1px 0 rgba(255, 255, 255, 0.9);
 		outline: none;
 	}
 
 	.passport-qr-stamp:focus-visible {
 		box-shadow:
-			0 0 0 3px rgba(236, 72, 153, 0.2),
-			0 10px 22px rgba(136, 82, 88, 0.18);
+			0 0 0 3px color-mix(in srgb, var(--p-accent) 40%, transparent),
+			0 10px 22px color-mix(in srgb, var(--p-glow) 24%, transparent);
 	}
 
 	.passport-qr-stamp img {
@@ -364,8 +666,12 @@
 		border-radius: 0.78rem;
 		background:
 			radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.86), transparent 45%),
-			linear-gradient(135deg, #fffdf0, color-mix(in srgb, var(--passport-shape) 22%, #fffdf0));
-		color: #374151;
+			linear-gradient(
+				135deg,
+				rgba(255, 255, 255, 0.9),
+				color-mix(in srgb, var(--p-accent) 22%, rgba(255, 255, 255, 0.7))
+			);
+		color: var(--p-ink);
 	}
 
 	.fallback-ghost {
@@ -374,8 +680,8 @@
 		width: 1.55rem;
 		height: 1.75rem;
 		border-radius: 999px 999px 0.72rem 0.72rem;
-		background: rgba(236, 72, 153, 0.82);
-		filter: drop-shadow(0 3px 0 rgba(255, 202, 212, 0.55));
+		background: var(--p-accent);
+		filter: drop-shadow(0 3px 0 color-mix(in srgb, var(--p-accent) 45%, #fff));
 	}
 
 	.fallback-ghost::before,
@@ -402,17 +708,18 @@
 		font-size: 0.54rem;
 		font-weight: 900;
 		letter-spacing: 0;
+		color: var(--p-ink);
 	}
 
 	.ghost-mark {
 		width: 32px;
 		height: 36px;
-		fill: rgba(255, 253, 240, 0.95);
-		filter: drop-shadow(0 3px 0 rgba(255, 202, 212, 0.45));
+		fill: rgba(255, 255, 255, 0.92);
+		filter: drop-shadow(0 3px 0 color-mix(in srgb, var(--p-accent) 42%, #fff));
 	}
 
 	.ghost-mark circle {
-		fill: #374151;
+		fill: var(--p-ink);
 	}
 
 	@media (max-width: 360px) {
@@ -437,17 +744,19 @@
 			animation: passportReveal 420ms cubic-bezier(0.2, 0.9, 0.2, 1.12) both;
 		}
 
-		.holofoil {
+		/* Idle drift only while at rest — once the pointer takes over it sets
+		   background-position directly, so the animation would fight it. */
+		.passport-card:not([style*='--hovered: 1']) .holofoil {
 			animation: foilDrift 7s ease-in-out infinite alternate;
 		}
 	}
 
 	.passport-card:not(.is-placeholder) {
 		transition:
-			transform 120ms ease,
+			transform 160ms ease,
 			box-shadow 120ms ease;
-		transform: perspective(600px) rotateX(calc((var(--my) - 50) * -0.06deg))
-			rotateY(calc((var(--mx) - 50) * 0.06deg));
+		transform: perspective(620px) rotateX(calc((var(--my) - 50) * -0.12deg))
+			rotateY(calc((var(--mx) - 50) * 0.12deg));
 	}
 
 	@keyframes passportReveal {
@@ -461,17 +770,15 @@
 		}
 	}
 
+	/* Idle shimmer: gently drift the spectral rainbow so the card breathes at
+	   rest. Position-only — the per-skin filter is left untouched so each holo
+	   keeps its own look. */
 	@keyframes foilDrift {
 		0% {
-			filter: hue-rotate(0deg) saturate(1);
-			transform: translateX(-2%) translateY(0);
-		}
-		50% {
-			filter: hue-rotate(12deg) saturate(1.08);
+			background-position: 0% 50%;
 		}
 		100% {
-			filter: hue-rotate(24deg) saturate(1.12);
-			transform: translateX(2%) translateY(-1%);
+			background-position: 100% 50%;
 		}
 	}
 </style>

--- a/src/lib/cartridges/passportAvatar.js
+++ b/src/lib/cartridges/passportAvatar.js
@@ -1,0 +1,34 @@
+/**
+ * Passport avatar — deterministic cute avatar from the vault hash.
+ *
+ * Uses DiceBear (offline SVG, no network → no CSP concerns). Each supporter
+ * gets a unique face seeded from their hash, themed to their palette's avatar
+ * style. Renders to a data-URI so it drops straight into an <img src>.
+ */
+
+import { createAvatar } from '@dicebear/core';
+import { funEmoji, thumbs, adventurer, bottts } from '@dicebear/collection';
+
+const COLLECTIONS = { funEmoji, thumbs, adventurer, bottts };
+
+/**
+ * Build a DiceBear avatar data-URI.
+ * @param {string} seed - stable seed (vault hash or member id)
+ * @param {string} style - collection key from the palette (funEmoji|thumbs|adventurer|bottts)
+ * @returns {string} data:image/svg+xml URI, or '' if generation fails
+ */
+export function buildPassportAvatar(seed, style = 'funEmoji') {
+	const collection = COLLECTIONS[style] || funEmoji;
+	try {
+		return createAvatar(collection, {
+			seed: seed || 'talktype',
+			radius: 50,
+			scale: 92,
+			backgroundType: ['solid'],
+			backgroundColor: ['transparent']
+		}).toDataUri();
+	} catch (error) {
+		console.warn('Passport avatar generation failed:', error);
+		return '';
+	}
+}

--- a/src/lib/cartridges/passportPalettes.js
+++ b/src/lib/cartridges/passportPalettes.js
@@ -1,0 +1,126 @@
+/**
+ * Passport palettes — modular, vibrant theme system for the supporter card.
+ *
+ * Each supporter gets a deterministic *themed* palette (not one washed pastel)
+ * derived from their vault hash. Palettes are rich and saturated by design —
+ * the card should feel like a collectible holo, not an office badge.
+ *
+ * Palette shape:
+ *   name      — human label (kept for debugging / future "your card: Sunset")
+ *   bg        — array of 2-3 hex stops for the main diagonal gradient
+ *   accent    — punchy colour for chips / shape pattern
+ *   ink       — text colour that stays legible on this bg
+ *   inkSoft   — secondary text colour
+ *   glow      — colour for the outer bloom / shadow tint
+ *   avatar    — DiceBear collection key (see passportAvatar.js)
+ */
+
+export const PASSPORT_PALETTES = [
+	{
+		name: 'Sunset',
+		bg: ['#ff9a8b', '#ff6a88', '#ff99ac'],
+		accent: '#ffd166',
+		ink: '#3d1029',
+		inkSoft: 'rgba(61, 16, 41, 0.66)',
+		glow: '#ff6a88',
+		avatar: 'thumbs'
+	},
+	{
+		name: 'Miami',
+		bg: ['#f9d423', '#ff6b6b', '#4ecdc4'],
+		accent: '#ff6b6b',
+		ink: '#15323a',
+		inkSoft: 'rgba(21, 50, 58, 0.64)',
+		glow: '#ff6b6b',
+		avatar: 'thumbs'
+	},
+	{
+		name: 'Lavender',
+		bg: ['#a18cd1', '#fbc2eb', '#c2a8f5'],
+		accent: '#7c5cff',
+		ink: '#26143f',
+		inkSoft: 'rgba(38, 20, 63, 0.62)',
+		glow: '#9370db',
+		avatar: 'adventurer'
+	},
+	{
+		name: 'Pool',
+		bg: ['#43e0c7', '#3fb8ff', '#6a8bff'],
+		accent: '#ffe066',
+		ink: '#0c2a3a',
+		inkSoft: 'rgba(12, 42, 58, 0.62)',
+		glow: '#3fb8ff',
+		avatar: 'adventurer'
+	},
+	{
+		name: 'Risograph',
+		bg: ['#ff48b0', '#7b5cff', '#0078bf'],
+		accent: '#ffe800',
+		ink: '#ffffff',
+		inkSoft: 'rgba(255, 255, 255, 0.82)',
+		glow: '#ff48b0',
+		avatar: 'thumbs'
+	},
+	{
+		name: 'Mango',
+		bg: ['#ffd200', '#ff7e5f', '#feb47b'],
+		accent: '#ff5e62',
+		ink: '#3a1605',
+		inkSoft: 'rgba(58, 22, 5, 0.6)',
+		glow: '#ff7e5f',
+		avatar: 'thumbs'
+	},
+	{
+		name: 'Grape Soda',
+		bg: ['#c471ed', '#f64f59', '#7c5cff'],
+		accent: '#ffd166',
+		ink: '#ffffff',
+		inkSoft: 'rgba(255, 255, 255, 0.8)',
+		glow: '#c471ed',
+		avatar: 'adventurer'
+	},
+	{
+		name: 'Spearmint',
+		bg: ['#2af598', '#08c2c2', '#43e0c7'],
+		accent: '#ff8fab',
+		ink: '#073227',
+		inkSoft: 'rgba(7, 50, 39, 0.6)',
+		glow: '#08c2c2',
+		avatar: 'adventurer'
+	}
+];
+
+// Soft, dashed placeholder used before a real supporter identity exists.
+export const PLACEHOLDER_PALETTE = {
+	name: 'Pending',
+	bg: ['#fff1f2', '#ffe4ef', '#ffeede'],
+	accent: '#f9a8d4',
+	ink: '#6b4a55',
+	inkSoft: 'rgba(107, 74, 85, 0.6)',
+	glow: '#f9a8d4',
+	avatar: 'thumbs'
+};
+
+/**
+ * Pick a deterministic palette from a vault hash.
+ * Uses a hash segment distinct from the name/avatar segments so the palette
+ * varies independently of the generated name.
+ */
+export function selectPassportPalette(vaultHash) {
+	const hash = typeof vaultHash === 'string' ? vaultHash.trim() : '';
+	if (!hash) return PLACEHOLDER_PALETTE;
+
+	const segment = hash.slice(48, 56) || hash.slice(0, 8) || hash;
+	const parsed = Number.parseInt(segment, 16);
+	let index;
+	if (Number.isFinite(parsed)) {
+		index = parsed % PASSPORT_PALETTES.length;
+	} else {
+		let total = 0;
+		for (let i = 0; i < segment.length; i += 1) {
+			total += segment.charCodeAt(i) * (i + 1);
+		}
+		index = total % PASSPORT_PALETTES.length;
+	}
+	return PASSPORT_PALETTES[index];
+}

--- a/src/lib/cartridges/passportPalettes.js
+++ b/src/lib/cartridges/passportPalettes.js
@@ -102,6 +102,46 @@ export const PLACEHOLDER_PALETTE = {
 };
 
 /**
+ * Convert a #rrggbb (or #rgb) hex colour to an `rgba(r, g, b, a)` string.
+ * Used to pre-mix glow/accent alphas in JS so the card never relies on CSS
+ * `color-mix()` at render time (unsupported before Safari 16.2 / Chrome 111).
+ * Non-hex input is returned as a `transparent` fallback.
+ */
+export function hexToRgba(hex, alpha = 1) {
+	if (typeof hex !== 'string') return 'transparent';
+	let h = hex.trim().replace(/^#/, '');
+	if (h.length === 3) h = h.replace(/./g, (c) => c + c);
+	if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) return 'transparent';
+	const r = parseInt(h.slice(0, 2), 16);
+	const g = parseInt(h.slice(2, 4), 16);
+	const b = parseInt(h.slice(4, 6), 16);
+	const a = Math.max(0, Math.min(1, alpha));
+	return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+function parseHex(hex) {
+	if (typeof hex !== 'string') return null;
+	let h = hex.trim().replace(/^#/, '');
+	if (h.length === 3) h = h.replace(/./g, (c) => c + c);
+	if (h.length !== 6 || /[^0-9a-fA-F]/.test(h)) return null;
+	return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+/**
+ * Blend `hex` toward `toward` (default white) by `amount` (0..1 of `hex`).
+ * `mixHex('#ff6a88', 0.45)` ≈ `color-mix(in srgb, #ff6a88 45%, #fff)`.
+ * Returns an `rgb()` string; falls back to the original input on bad hex.
+ */
+export function mixHex(hex, amount = 0.5, toward = '#ffffff') {
+	const a = parseHex(hex);
+	const b = parseHex(toward);
+	if (!a || !b) return hex;
+	const t = Math.max(0, Math.min(1, amount));
+	const m = (i) => Math.round(a[i] * t + b[i] * (1 - t));
+	return `rgb(${m(0)}, ${m(1)}, ${m(2)})`;
+}
+
+/**
  * Pick a deterministic palette from a vault hash.
  * Uses a hash segment distinct from the name/avatar segments so the palette
  * varies independently of the generated name.

--- a/src/lib/cartridges/passportPalettes.test.js
+++ b/src/lib/cartridges/passportPalettes.test.js
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
 	PASSPORT_PALETTES,
 	PLACEHOLDER_PALETTE,
-	selectPassportPalette
+	selectPassportPalette,
+	hexToRgba,
+	mixHex
 } from './passportPalettes.js';
 
 describe('passport palette selection', () => {
@@ -30,6 +32,38 @@ describe('passport palette selection', () => {
 			expect(palette.inkSoft).toBeTruthy();
 			expect(palette.glow).toBeTruthy();
 			expect(['funEmoji', 'thumbs', 'adventurer', 'bottts']).toContain(palette.avatar);
+		}
+	});
+});
+
+describe('colour helpers (color-mix replacements)', () => {
+	it('hexToRgba converts 6- and 3-digit hex with clamped alpha', () => {
+		expect(hexToRgba('#ff6a88', 0.38)).toBe('rgba(255, 106, 136, 0.38)');
+		expect(hexToRgba('#fff', 1)).toBe('rgba(255, 255, 255, 1)');
+		expect(hexToRgba('#000000', 2)).toBe('rgba(0, 0, 0, 1)');
+		expect(hexToRgba('#000000', -1)).toBe('rgba(0, 0, 0, 0)');
+	});
+
+	it('hexToRgba returns transparent for bad input', () => {
+		expect(hexToRgba('garbage')).toBe('transparent');
+		expect(hexToRgba(undefined)).toBe('transparent');
+		expect(hexToRgba('#12')).toBe('transparent');
+	});
+
+	it('mixHex blends toward white by amount', () => {
+		expect(mixHex('#000000', 0)).toBe('rgb(255, 255, 255)');
+		expect(mixHex('#000000', 1)).toBe('rgb(0, 0, 0)');
+		expect(mixHex('#ffffff', 0.5)).toBe('rgb(255, 255, 255)');
+	});
+
+	it('mixHex returns the original input on bad hex', () => {
+		expect(mixHex('nope', 0.5)).toBe('nope');
+	});
+
+	it('every palette glow/accent is valid hex (so the helpers never fall back)', () => {
+		for (const p of [...PASSPORT_PALETTES, PLACEHOLDER_PALETTE]) {
+			expect(hexToRgba(p.glow, 0.5)).not.toBe('transparent');
+			expect(hexToRgba(p.accent, 0.5)).not.toBe('transparent');
 		}
 	});
 });

--- a/src/lib/cartridges/passportPalettes.test.js
+++ b/src/lib/cartridges/passportPalettes.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+	PASSPORT_PALETTES,
+	PLACEHOLDER_PALETTE,
+	selectPassportPalette
+} from './passportPalettes.js';
+
+describe('passport palette selection', () => {
+	const hash = 'abcdef123456abcdef123456abcdef123456abcdef123456abcdef123456abcd';
+
+	it('is deterministic for the same hash', () => {
+		expect(selectPassportPalette(hash)).toBe(selectPassportPalette(hash));
+	});
+
+	it('returns a real palette from the set for a valid hash', () => {
+		expect(PASSPORT_PALETTES).toContain(selectPassportPalette(hash));
+	});
+
+	it('falls back to the placeholder palette for an empty hash', () => {
+		expect(selectPassportPalette('')).toBe(PLACEHOLDER_PALETTE);
+		expect(selectPassportPalette(undefined)).toBe(PLACEHOLDER_PALETTE);
+	});
+
+	it('every palette has the fields the card needs', () => {
+		for (const palette of [...PASSPORT_PALETTES, PLACEHOLDER_PALETTE]) {
+			expect(Array.isArray(palette.bg)).toBe(true);
+			expect(palette.bg.length).toBeGreaterThanOrEqual(2);
+			expect(palette.accent).toBeTruthy();
+			expect(palette.ink).toBeTruthy();
+			expect(palette.inkSoft).toBeTruthy();
+			expect(palette.glow).toBeTruthy();
+			expect(['funEmoji', 'thumbs', 'adventurer', 'bottts']).toContain(palette.avatar);
+		}
+	});
+});

--- a/src/lib/cartridges/passportSkins.js
+++ b/src/lib/cartridges/passportSkins.js
@@ -1,0 +1,328 @@
+/**
+ * Passport skins — a modular, orthogonal theming system for the supporter card.
+ *
+ * The card aesthetic is decomposed into independent AXES. Each axis is a small
+ * list of options, and every option is just a bag of CSS custom properties
+ * (plus, for the avatar axis, a DiceBear collection key). The component spreads
+ * the resolved vars into its inline style and the CSS reacts — no per-skin
+ * markup branches.
+ *
+ * A "skin" is one coordinate in this space: one option chosen per axis. Because
+ * the axes are independent, a handful of small definitions multiply into
+ * thousands of combinations. Each supporter gets a deterministic coordinate
+ * from their vault hash (full shuffle per axis → every card one-of-a-kind).
+ *
+ * Named presets (NEON_BRUT, HACKER, UNICORN, VIBRANT) are curated coordinates
+ * used as anchors / dev previews. `shuffleSkinSeed()` makes a wild one.
+ *
+ * To add design entropy later: add an option to any axis. Every other axis
+ * recombines with it for free.
+ */
+
+import { selectPassportPalette, PASSPORT_PALETTES } from './passportPalettes.js';
+
+/* ===================================================================
+   AXIS: HOLO — the foil technique. Drives the .holofoil layer via vars.
+   --holo-angle      gradient sweep angle
+   --holo-size       background-size of the rainbow (bigger = slower sweep)
+   --holo-blend      mix-blend-mode of the foil
+   --holo-filter     filter applied to the foil
+   --holo-rest/-bloom opacity floor + how much pointer movement adds
+   --holo-c1..c6     the six spectral stops (so palettes can stay coherent)
+   --holo-scan-*     the texture is a separate axis, but holo sets its tint
+   =================================================================== */
+const SPECTRAL = {
+	'--holo-c1': 'hsl(320, 100%, 70%)',
+	'--holo-c2': 'hsl(30, 100%, 65%)',
+	'--holo-c3': 'hsl(58, 100%, 65%)',
+	'--holo-c4': 'hsl(160, 100%, 55%)',
+	'--holo-c5': 'hsl(205, 100%, 65%)',
+	'--holo-c6': 'hsl(270, 100%, 72%)'
+};
+
+const HOLO = {
+	rainbow: {
+		// Lush full-spectrum metallic sheen (the current "Vibrant" look).
+		...SPECTRAL,
+		'--holo-angle': '110deg',
+		'--holo-size': '400% 400%',
+		'--holo-blend': 'color-dodge',
+		'--holo-filter': 'brightness(0.95) contrast(1.45) saturate(1.7)',
+		'--holo-rest': '0.4',
+		'--holo-bloom': '0.55'
+	},
+	oily: {
+		// Oily CRT iridescence — tighter bands, soft-light so it reads on dark.
+		'--holo-c1': 'hsl(150, 90%, 55%)',
+		'--holo-c2': 'hsl(180, 90%, 55%)',
+		'--holo-c3': 'hsl(280, 80%, 60%)',
+		'--holo-c4': 'hsl(120, 90%, 50%)',
+		'--holo-c5': 'hsl(200, 90%, 55%)',
+		'--holo-c6': 'hsl(300, 80%, 58%)',
+		'--holo-angle': '125deg',
+		'--holo-size': '260% 260%',
+		'--holo-blend': 'color-dodge',
+		'--holo-filter': 'brightness(0.85) contrast(1.7) saturate(1.5) hue-rotate(0deg)',
+		'--holo-rest': '0.34',
+		'--holo-bloom': '0.5'
+	},
+	pearl: {
+		// Pearlescent — desaturated, soft, premium. Restrained shimmer.
+		'--holo-c1': 'hsl(320, 60%, 88%)',
+		'--holo-c2': 'hsl(40, 60%, 88%)',
+		'--holo-c3': 'hsl(160, 50%, 88%)',
+		'--holo-c4': 'hsl(200, 60%, 90%)',
+		'--holo-c5': 'hsl(270, 55%, 90%)',
+		'--holo-c6': 'hsl(330, 55%, 90%)',
+		'--holo-angle': '105deg',
+		'--holo-size': '320% 320%',
+		'--holo-blend': 'soft-light',
+		'--holo-filter': 'brightness(1.08) contrast(1.05) saturate(1.1)',
+		'--holo-rest': '0.18',
+		'--holo-bloom': '0.34'
+	},
+	prismatic: {
+		// Prismatic sigil — sharp, high-contrast spectral, screen blend for glow.
+		...SPECTRAL,
+		'--holo-angle': '135deg',
+		'--holo-size': '500% 500%',
+		'--holo-blend': 'screen',
+		'--holo-filter': 'brightness(1.0) contrast(1.5) saturate(1.8)',
+		'--holo-rest': '0.22',
+		'--holo-bloom': '0.5'
+	}
+};
+
+/* ===================================================================
+   AXIS: FRAME — border, radius, shadow shape. Drives .passport-card.
+   =================================================================== */
+// --f-substrate is an overlay tint painted under the content: transparent for
+// light frames, a dark wash for terminal so "hacker" reads dark regardless of
+// which palette the hash picked. --f-ink-shift flips text toward light on dark.
+const FRAME = {
+	chunky: {
+		'--f-radius': '1.55rem',
+		'--f-border': '3px solid rgba(0, 0, 0, 0.82)',
+		'--f-shadow': '8px 8px 0 rgba(0, 0, 0, 0.82), 0 18px 40px var(--f-glow-38)',
+		'--f-substrate': 'transparent',
+		'--f-ink-shift': '0'
+	},
+	soft: {
+		'--f-radius': '1.55rem',
+		'--f-border': '2px solid rgba(255, 255, 255, 0.38)',
+		'--f-shadow':
+			'0 24px 48px var(--f-glow-38), 0 8px 18px var(--f-glow-20), 0 3px 0 rgba(255, 255, 255, 0.22) inset',
+		'--f-substrate': 'transparent',
+		'--f-ink-shift': '0'
+	},
+	hairline: {
+		'--f-radius': '1.1rem',
+		'--f-border': '1px solid rgba(255, 255, 255, 0.55)',
+		'--f-shadow': '0 16px 40px var(--f-glow-20), 0 2px 10px rgba(0, 0, 0, 0.06)',
+		'--f-substrate': 'rgba(255, 255, 255, 0.42)',
+		'--f-ink-shift': '0'
+	},
+	terminal: {
+		'--f-radius': '0.5rem',
+		'--f-border': '1px solid var(--p-accent)',
+		'--f-shadow':
+			'0 0 0 1px rgba(0, 0, 0, 0.6), 0 0 22px var(--f-glow-38), 0 18px 40px rgba(0, 0, 0, 0.55)',
+		'--f-substrate': 'rgba(8, 10, 16, 0.86)',
+		'--f-ink-shift': '1'
+	}
+};
+
+/* ===================================================================
+   AXIS: TEXTURE — surface overlay. Drives the .passport-texture layer.
+   --tx-image / --tx-size / --tx-blend / --tx-opacity
+   =================================================================== */
+const NO_TEXTURE = {
+	'--tx-image': 'none',
+	'--tx-size': 'auto',
+	'--tx-blend': 'normal',
+	'--tx-opacity': '0'
+};
+const TEXTURE = {
+	none: NO_TEXTURE,
+	scanlines: {
+		'--tx-image':
+			'repeating-linear-gradient(0deg, rgba(0,0,0,0.0) 0px, rgba(0,0,0,0.22) 1px, rgba(0,0,0,0.0) 3px)',
+		'--tx-size': '100% 3px',
+		'--tx-blend': 'multiply',
+		'--tx-opacity': '0.5'
+	},
+	grain: {
+		'--tx-image':
+			'repeating-conic-gradient(rgba(255,255,255,0.05) 0% 25%, rgba(0,0,0,0.05) 0% 50%)',
+		'--tx-size': '4px 4px',
+		'--tx-blend': 'overlay',
+		'--tx-opacity': '0.4'
+	},
+	halftone: {
+		'--tx-image':
+			'radial-gradient(rgba(0,0,0,0.18) 22%, transparent 23%)',
+		'--tx-size': '7px 7px',
+		'--tx-blend': 'multiply',
+		'--tx-opacity': '0.4'
+	},
+	sparkle: {
+		'--tx-image':
+			'radial-gradient(rgba(255,255,255,0.9) 9%, transparent 10%), radial-gradient(rgba(255,255,255,0.7) 7%, transparent 8%)',
+		'--tx-size': '26px 26px, 17px 17px',
+		'--tx-blend': 'screen',
+		'--tx-opacity': '0.5'
+	}
+};
+
+/* ===================================================================
+   AXIS: TYPE — font, casing, tracking. Drives text in the card.
+   =================================================================== */
+const TYPE = {
+	display: {
+		'--t-font': "'Poppins', system-ui, sans-serif",
+		'--t-name-size': '1.56rem',
+		'--t-name-weight': '900',
+		'--t-transform': 'none',
+		'--t-tracking': '0'
+	},
+	mono: {
+		'--t-font': "'JetBrains Mono', ui-monospace, 'SFMono-Regular', monospace",
+		'--t-name-size': '1.28rem',
+		'--t-name-weight': '700',
+		'--t-transform': 'uppercase',
+		'--t-tracking': '0.04em'
+	},
+	airy: {
+		'--t-font': "'Poppins', system-ui, sans-serif",
+		'--t-name-size': '1.4rem',
+		'--t-name-weight': '300',
+		'--t-transform': 'none',
+		'--t-tracking': '0.12em'
+	}
+};
+
+/* ===================================================================
+   AXIS: AVATAR — DiceBear collection (not a CSS var; a style key).
+   thumbs/adventurer are the cute character styles Pablo liked.
+   =================================================================== */
+const AVATAR = ['thumbs', 'adventurer', 'bottts', 'funEmoji'];
+
+/* The axis registry — order matters only for stable hash mapping. */
+export const SKIN_AXES = {
+	holo: HOLO,
+	frame: FRAME,
+	texture: TEXTURE,
+	type: TYPE,
+	avatar: AVATAR
+};
+
+/* ===================================================================
+   NAMED PRESETS — curated coordinates. Used as anchors / previews.
+   Each names an option per axis (palette index is optional; if omitted
+   the palette is taken from the hash like everything else).
+   =================================================================== */
+export const NAMED_SKINS = {
+	vibrant: { holo: 'rainbow', frame: 'soft', texture: 'sparkle', type: 'display', avatar: 'thumbs' },
+	neonBrut: { holo: 'rainbow', frame: 'chunky', texture: 'halftone', type: 'display', avatar: 'thumbs' },
+	hacker: { holo: 'oily', frame: 'terminal', texture: 'scanlines', type: 'mono', avatar: 'bottts' },
+	unicorn: { holo: 'pearl', frame: 'hairline', texture: 'none', type: 'airy', avatar: 'adventurer' }
+};
+
+// Keys of each axis, cached for indexable selection.
+const AXIS_KEYS = {
+	holo: Object.keys(HOLO),
+	frame: Object.keys(FRAME),
+	texture: Object.keys(TEXTURE),
+	type: Object.keys(TYPE),
+	avatar: AVATAR
+};
+
+// Pull an integer from a slice of the hash (hex), fallback to char-sum.
+function hashSlice(hash, start, len = 4) {
+	const seg = hash.slice(start, start + len) || hash.slice(0, len) || hash;
+	const parsed = Number.parseInt(seg, 16);
+	if (Number.isFinite(parsed)) return parsed;
+	let total = 0;
+	for (let i = 0; i < seg.length; i += 1) total += seg.charCodeAt(i) * (i + 1);
+	return total;
+}
+
+// Resolve a {holo, frame, texture, type, avatar} choice-map into a single
+// flat object of CSS vars (+ the avatar style key).
+function resolveVars(choices) {
+	const vars = {};
+	Object.assign(vars, HOLO[choices.holo] || HOLO.rainbow);
+	Object.assign(vars, FRAME[choices.frame] || FRAME.soft);
+	Object.assign(vars, TEXTURE[choices.texture] || TEXTURE.sparkle);
+	Object.assign(vars, TYPE[choices.type] || TYPE.display);
+	return vars;
+}
+
+/**
+ * Deterministically pick a full skin coordinate from a vault hash.
+ * Each axis reads a DISTINCT hash slice so they shuffle independently.
+ *
+ * @returns {{ name, palette, choices, vars, avatarStyle, varString }}
+ */
+export function selectSkin(vaultHash) {
+	const hash = typeof vaultHash === 'string' && vaultHash.trim() ? vaultHash.trim() : '';
+	const palette = selectPassportPalette(hash);
+
+	if (!hash) {
+		// Placeholder → calm vibrant defaults.
+		const choices = NAMED_SKINS.vibrant;
+		return finalize('pending', palette, choices);
+	}
+
+	const choices = {
+		holo: AXIS_KEYS.holo[hashSlice(hash, 8) % AXIS_KEYS.holo.length],
+		frame: AXIS_KEYS.frame[hashSlice(hash, 16) % AXIS_KEYS.frame.length],
+		texture: AXIS_KEYS.texture[hashSlice(hash, 24) % AXIS_KEYS.texture.length],
+		type: AXIS_KEYS.type[hashSlice(hash, 32) % AXIS_KEYS.type.length],
+		avatar: AXIS_KEYS.avatar[hashSlice(hash, 40) % AXIS_KEYS.avatar.length]
+	};
+	return finalize('shuffle', palette, choices);
+}
+
+/**
+ * Resolve a named preset (e.g. 'hacker') against a hash for the palette.
+ * Useful for forcing a skin in dev/preview or future user-pick.
+ */
+export function selectNamedSkin(name, vaultHash) {
+	const choices = NAMED_SKINS[name] || NAMED_SKINS.vibrant;
+	const palette = selectPassportPalette(vaultHash);
+	return finalize(name, palette, choices);
+}
+
+/**
+ * A fully random skin for shuffle/preview. `seed` only varies which options
+ * get picked deterministically (no Math.random — keeps things reproducible
+ * and SSR-safe). Pass an incrementing integer to walk the space.
+ */
+export function shuffleSkinSeed(seed = 0) {
+	const pick = (arr, salt) => arr[Math.abs((seed * 2654435761 + salt * 40503) >>> 0) % arr.length];
+	const choices = {
+		holo: pick(AXIS_KEYS.holo, 1),
+		frame: pick(AXIS_KEYS.frame, 2),
+		texture: pick(AXIS_KEYS.texture, 3),
+		type: pick(AXIS_KEYS.type, 4),
+		avatar: pick(AXIS_KEYS.avatar, 5)
+	};
+	const palette = PASSPORT_PALETTES[Math.abs((seed * 18000) >>> 0) % PASSPORT_PALETTES.length];
+	return finalize('shuffle', palette, choices);
+}
+
+function finalize(name, palette, choices) {
+	const vars = resolveVars(choices);
+	const varString = Object.entries(vars)
+		.map(([k, v]) => `${k}: ${v}`)
+		.join('; ');
+	return {
+		name,
+		palette,
+		choices,
+		vars,
+		avatarStyle: choices.avatar || palette.avatar,
+		varString
+	};
+}

--- a/src/lib/cartridges/passportSkins.js
+++ b/src/lib/cartridges/passportSkins.js
@@ -102,8 +102,8 @@ const HOLO = {
 const FRAME = {
 	chunky: {
 		'--f-radius': '1.55rem',
-		'--f-border': '3px solid rgba(0, 0, 0, 0.82)',
-		'--f-shadow': '8px 8px 0 rgba(0, 0, 0, 0.82), 0 18px 40px var(--f-glow-38)',
+		'--f-border': '3px solid rgba(0, 0, 0, 0.78)',
+		'--f-shadow': '7px 7px 0 rgba(0, 0, 0, 0.65), 0 18px 40px var(--f-glow-38)',
 		'--f-substrate': 'transparent',
 		'--f-ink-shift': '0'
 	},
@@ -119,7 +119,8 @@ const FRAME = {
 		'--f-radius': '1.1rem',
 		'--f-border': '1px solid rgba(255, 255, 255, 0.55)',
 		'--f-shadow': '0 16px 40px var(--f-glow-20), 0 2px 10px rgba(0, 0, 0, 0.06)',
-		'--f-substrate': 'rgba(255, 255, 255, 0.42)',
+		// 0.22 (was 0.42): a 42% white wash fogged vivid cool gradients to grey.
+		'--f-substrate': 'rgba(255, 255, 255, 0.22)',
 		'--f-ink-shift': '0'
 	},
 	terminal: {
@@ -195,7 +196,8 @@ const TYPE = {
 	airy: {
 		'--t-font': "'Poppins', system-ui, sans-serif",
 		'--t-name-size': '1.4rem',
-		'--t-name-weight': '300',
+		// 500 floor: weight 300 lost contrast on saturated gradients (WCAG fail).
+		'--t-name-weight': '500',
 		'--t-transform': 'none',
 		'--t-tracking': '0.12em'
 	}
@@ -308,12 +310,32 @@ export function shuffleSkinSeed(seed = 0) {
 		type: pick(AXIS_KEYS.type, 4),
 		avatar: pick(AXIS_KEYS.avatar, 5)
 	};
-	const palette = PASSPORT_PALETTES[Math.abs((seed * 18000) >>> 0) % PASSPORT_PALETTES.length];
+	// 18000 % 8 === 0 made every seed pick palette[0]; use an odd multiplier.
+	const palette =
+		PASSPORT_PALETTES[Math.abs((seed * 2654435761 + 37) >>> 0) % PASSPORT_PALETTES.length];
 	return finalize('shuffle', palette, choices);
 }
 
+// White-ink palettes (Risograph, Grape Soda) sit on vivid saturated gradients.
+// The dodging holos (color-dodge / screen) blow those backgrounds toward white
+// and bury the white text. Cap their intensity so the foil stays iridescent
+// rather than bleaching the card.
+const WHITE_INK = '#ffffff';
+function guardHoloForInk(vars, palette) {
+	if (palette.ink !== WHITE_INK) return vars;
+	const blend = vars['--holo-blend'];
+	if (blend === 'color-dodge' || blend === 'screen') {
+		return {
+			...vars,
+			'--holo-rest': '0.24',
+			'--holo-bloom': '0.36'
+		};
+	}
+	return vars;
+}
+
 function finalize(name, palette, choices) {
-	const vars = resolveVars(choices);
+	const vars = guardHoloForInk(resolveVars(choices), palette);
 	const varString = Object.entries(vars)
 		.map(([k, v]) => `${k}: ${v}`)
 		.join('; ');
@@ -322,7 +344,8 @@ function finalize(name, palette, choices) {
 		palette,
 		choices,
 		vars,
-		avatarStyle: choices.avatar || palette.avatar,
+		// Always set from the AVATAR axis; palette.avatar is a pre-refactor legacy field.
+		avatarStyle: choices.avatar,
 		varString
 	};
 }

--- a/src/lib/cartridges/passportSkins.js
+++ b/src/lib/cartridges/passportSkins.js
@@ -99,11 +99,15 @@ const HOLO = {
 // --f-substrate is an overlay tint painted under the content: transparent for
 // light frames, a dark wash for terminal so "hacker" reads dark regardless of
 // which palette the hash picked. --f-ink-shift flips text toward light on dark.
+// --f-filter is applied to the tilting card element, so any drop-shadow in it
+// follows the 3D transform. chunky's hard offset lives here (not box-shadow) so
+// the toy-shadow tilts WITH the card instead of staying flat behind it.
 const FRAME = {
 	chunky: {
 		'--f-radius': '1.55rem',
 		'--f-border': '3px solid rgba(0, 0, 0, 0.78)',
-		'--f-shadow': '7px 7px 0 rgba(0, 0, 0, 0.65), 0 18px 40px var(--f-glow-38)',
+		'--f-shadow': '0 18px 40px var(--f-glow-38)',
+		'--f-filter': 'drop-shadow(7px 7px 0 rgba(0, 0, 0, 0.65))',
 		'--f-substrate': 'transparent',
 		'--f-ink-shift': '0'
 	},
@@ -112,6 +116,7 @@ const FRAME = {
 		'--f-border': '2px solid rgba(255, 255, 255, 0.38)',
 		'--f-shadow':
 			'0 24px 48px var(--f-glow-38), 0 8px 18px var(--f-glow-20), 0 3px 0 rgba(255, 255, 255, 0.22) inset',
+		'--f-filter': 'none',
 		'--f-substrate': 'transparent',
 		'--f-ink-shift': '0'
 	},
@@ -119,6 +124,7 @@ const FRAME = {
 		'--f-radius': '1.1rem',
 		'--f-border': '1px solid rgba(255, 255, 255, 0.55)',
 		'--f-shadow': '0 16px 40px var(--f-glow-20), 0 2px 10px rgba(0, 0, 0, 0.06)',
+		'--f-filter': 'none',
 		// 0.22 (was 0.42): a 42% white wash fogged vivid cool gradients to grey.
 		'--f-substrate': 'rgba(255, 255, 255, 0.22)',
 		'--f-ink-shift': '0'
@@ -128,6 +134,7 @@ const FRAME = {
 		'--f-border': '1px solid var(--p-accent)',
 		'--f-shadow':
 			'0 0 0 1px rgba(0, 0, 0, 0.6), 0 0 22px var(--f-glow-38), 0 18px 40px rgba(0, 0, 0, 0.55)',
+		'--f-filter': 'none',
 		'--f-substrate': 'rgba(8, 10, 16, 0.86)',
 		'--f-ink-shift': '1'
 	}

--- a/src/lib/cartridges/passportSkins.test.js
+++ b/src/lib/cartridges/passportSkins.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+	selectSkin,
+	selectNamedSkin,
+	shuffleSkinSeed,
+	NAMED_SKINS,
+	SKIN_AXES
+} from './passportSkins.js';
+
+const HASH = 'abcdef123456abcdef123456abcdef123456abcdef123456abcdef123456abcd';
+
+describe('passport skins', () => {
+	it('is deterministic for the same hash', () => {
+		expect(selectSkin(HASH)).toEqual(selectSkin(HASH));
+	});
+
+	it('resolves one valid option per axis from the hash', () => {
+		const { choices } = selectSkin(HASH);
+		expect(Object.keys(SKIN_AXES.holo)).toContain(choices.holo);
+		expect(Object.keys(SKIN_AXES.frame)).toContain(choices.frame);
+		expect(Object.keys(SKIN_AXES.texture)).toContain(choices.texture);
+		expect(Object.keys(SKIN_AXES.type)).toContain(choices.type);
+		expect(SKIN_AXES.avatar).toContain(choices.avatar);
+	});
+
+	it('produces a CSS var string and an avatar style', () => {
+		const skin = selectSkin(HASH);
+		expect(skin.varString).toContain('--holo-');
+		expect(skin.varString).toContain('--f-');
+		expect(skin.varString).toContain('--tx-');
+		expect(skin.varString).toContain('--t-');
+		expect(['thumbs', 'adventurer', 'bottts', 'funEmoji']).toContain(skin.avatarStyle);
+	});
+
+	it('falls back to a calm default for an empty hash', () => {
+		const skin = selectSkin('');
+		expect(skin.name).toBe('pending');
+		expect(skin.palette.name).toBe('Pending');
+	});
+
+	it('resolves every named preset to valid choices', () => {
+		for (const name of Object.keys(NAMED_SKINS)) {
+			const skin = selectNamedSkin(name, HASH);
+			expect(skin.choices).toEqual(NAMED_SKINS[name]);
+			expect(skin.varString.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('shuffle is reproducible per seed and varies across seeds', () => {
+		expect(shuffleSkinSeed(7)).toEqual(shuffleSkinSeed(7));
+		const labels = new Set(
+			Array.from({ length: 12 }, (_, i) => {
+				const c = shuffleSkinSeed(i).choices;
+				return `${c.holo}/${c.frame}/${c.texture}/${c.type}`;
+			})
+		);
+		// Expect real entropy: not all 12 seeds collapse to one combo.
+		expect(labels.size).toBeGreaterThan(3);
+	});
+});

--- a/src/lib/cartridges/passportSkins.test.js
+++ b/src/lib/cartridges/passportSkins.test.js
@@ -57,4 +57,24 @@ describe('passport skins', () => {
 		// Expect real entropy: not all 12 seeds collapse to one combo.
 		expect(labels.size).toBeGreaterThan(3);
 	});
+
+	it('shuffle varies the palette across seeds (regression: was always Sunset)', () => {
+		const palettes = new Set(
+			Array.from({ length: 20 }, (_, i) => shuffleSkinSeed(i).palette.name)
+		);
+		expect(palettes.size).toBeGreaterThan(3);
+	});
+
+	it('caps dodging holos on white-ink palettes so they do not blow out', () => {
+		// Find a hash that lands a white-ink palette + a color-dodge/screen holo.
+		for (let n = 0; n < 4000; n += 1) {
+			const h = n.toString(16).padStart(8, '0').repeat(8).slice(0, 64);
+			const skin = selectSkin(h);
+			const blend = skin.vars['--holo-blend'];
+			if (skin.palette.ink === '#ffffff' && (blend === 'color-dodge' || blend === 'screen')) {
+				expect(Number(skin.vars['--holo-rest'])).toBeLessThanOrEqual(0.26);
+				return;
+			}
+		}
+	});
 });


### PR DESCRIPTION
Rebuilds the supporter passport/membership card from "faded officey" into a lush, collectible holo card with a modular skin system.

## What changed

**The holofoil** — adapts the [simeydotme/pokemon-cards-css](https://github.com/simeydotme/pokemon-cards-css) technique: a pointer-tracked spectral foil with a radial *reveal mask* (foil brightest where you point, fading to the edges) so light *intensifies* the holo instead of painting a white hotspot. Soft wide glare, gyroscope tilt on mobile.

**Modular skin system** (`passportSkins.js`) — the card aesthetic is decomposed into orthogonal axes (holo · frame · texture · type · avatar · palette), each a bag of CSS vars. Full shuffle per axis from the vault hash → every supporter gets a one-of-a-kind card. Named presets: `vibrant`, `neonBrut`, `hacker`, `unicorn`.

**Vibrant palettes** (`passportPalettes.js`) replace the washed-out pastels. **DiceBear avatars** (`passportAvatar.js`), offline SVG, seeded per hash.

## Review applied

Reviewed by Stacey (UX/UI), Vince (visual taste/perf), and Rex (code). Their findings are folded in:
- 🔴 fixed `shuffleSkinSeed` always returning Sunset (`18000 % 8 === 0`) + a broken `box-shadow` comma
- ♿️ `prefers-reduced-motion` gates the 3D tilt + gyro; tilt button is now a ≥44px tap target
- 🎨 capped color-dodge holos on white-ink palettes; `airy` weight floor; de-fogged the hairline substrate; de-tombstoned the chunky shadow (now follows the tilt)
- ⚡️ split static vs per-frame CSS vars (no 1kb string rebuild 60×/sec) + `will-change`
- 🛡️ removed all `color-mix()` dependency (renders on Safari < 16.2 / Chrome < 111); QR "tap to sync" affordance on touch

## Notes

- The card was also extracted into a standalone library, [holopass](https://github.com/pibulus/holopass). TalkType keeps its own copy here for now (de-dupe later).
- **172/172 tests pass, prod build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)